### PR TITLE
Accessibility: Mailto and PDF links

### DIFF
--- a/pages/agenda/2015.tsx
+++ b/pages/agenda/2015.tsx
@@ -153,8 +153,8 @@ class Agenda2015 extends React.Component<AgendaPageProps> {
         </div>
         <h2>Handbook</h2>
         <p>
-          <a href={From2015.HandbookUrl} className="btn">
-            Download 2015 handbook
+          <a className="btn btn-pdf" href={From2015.HandbookUrl}>
+            Download 2015 Handbook (PDF)
           </a>
         </p>
         <h2>Media</h2>

--- a/pages/agenda/2016.tsx
+++ b/pages/agenda/2016.tsx
@@ -178,8 +178,8 @@ class Agenda2016 extends React.Component<AgendaPageProps> {
         </div>
         <h2>Handbook</h2>
         <p>
-          <a href={From2016.HandbookUrl} className="btn">
-            Download 2016 handbook
+          <a className="btn btn-pdf" href={From2016.HandbookUrl}>
+            Download 2015 Handbook (PDF)
           </a>
         </p>
         <h2>Media</h2>

--- a/pages/agenda/2017.tsx
+++ b/pages/agenda/2017.tsx
@@ -197,8 +197,8 @@ class Agenda2017 extends React.Component<AgendaPageProps> {
         </div>
         <h2>Handbook</h2>
         <p>
-          <a href={From2017.HandbookUrl} className="btn">
-            Download 2017 handbook
+          <a className="btn btn-pdf" href={From2017.HandbookUrl}>
+            Download 2017 handbook (PDF)
           </a>
         </p>
         <h2>Media</h2>

--- a/pages/sponsorship.tsx
+++ b/pages/sponsorship.tsx
@@ -8,7 +8,11 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
     <h1>Sponsorship</h1>
 
     <p>
-      <a className="btn" href={'mailto:' + props.pageMetadata.conference.SponsorshipEmail}>
+      <a
+        className="btn btn-mail"
+        href={'mailto:' + props.pageMetadata.conference.SponsorshipEmail}
+        title="Opens in your mail program of choice"
+      >
         Explore sponsorship opportunities
       </a>
     </p>
@@ -61,7 +65,11 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
     </p>
 
     <p>
-      <a className="btn" href={'mailto:' + props.pageMetadata.conference.SponsorshipEmail}>
+      <a
+        className="btn btn-mail"
+        href={'mailto:' + props.pageMetadata.conference.SponsorshipEmail}
+        title="Opens in your mail program of choice"
+      >
         Explore sponsorship opportunities
       </a>
     </p>

--- a/styles/screen.scss
+++ b/styles/screen.scss
@@ -39,7 +39,6 @@ hr {
   background: $primary-color;
   color: #fff !important;
 }
-
 .btn:after {
   content: '\f0da';
   font-family: 'FontAwesome';
@@ -54,7 +53,14 @@ hr {
   top: -1px;
 }
 .btn-mail:after {
-  content: '\f0e0';
+  @include opacity(1);
+  content: '\f003';
+  color: #fff;
+}
+.btn-pdf:after {
+  @include opacity(1);
+  content: '\f1c1';
+  color: #fff;
 }
 .btn:hover {
   background: darken($primary-color, 5%);

--- a/styles/screen.scss
+++ b/styles/screen.scss
@@ -53,6 +53,9 @@ hr {
   position: relative;
   top: -1px;
 }
+.btn-mail:after {
+  content: '\f0e0';
+}
 .btn:hover {
   background: darken($primary-color, 5%);
   color: #fff;


### PR DESCRIPTION
- Added PDF icon to handbook links
- Added mail icon to `mailto:` links
- Added title to mailto links explaining that the link will open in the systems default mail app

Previews:
![image](https://user-images.githubusercontent.com/5493721/40001774-87266094-57c1-11e8-9619-fab3dae18198.png)
![image](https://user-images.githubusercontent.com/5493721/40001798-9430d6c0-57c1-11e8-841f-2f602bc2a5bc.png)

Related issues:
https://github.com/dddwa/dddperth-website/issues/54
https://github.com/dddwa/dddperth-website/issues/60