### PR TITLE
Accessibility: Add text shadow and darken low contrast buttons

### DIFF
--- a/styles/screen.scss
+++ b/styles/screen.scss
@@ -38,6 +38,7 @@ hr {
   @include transition(0.2s);
   background: $primary-color;
   color: #fff !important;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
 }
 
 .btn:after {
@@ -96,19 +97,19 @@ a.btn {
 .btn.tickets,
 .btn-secondary,
 .btn.add-vote {
-  background-color: $tickets;
+  background-color: darken($tickets, 5%);
 }
 .btn.tickets:hover,
 .btn-secondary:hover,
 .btn.add-vote:hover {
-  background-color: darken($tickets, 5%);
+  background-color: darken($tickets, 10%);
 }
 
 .btn.agenda {
-  background-color: $agenda;
+  background-color: darken($agenda, 5%);
 }
 .btn.agenda:hover {
-  background-color: darken($agenda, 5%);
+  background-color: darken($agenda, 10%);
 }
 
 $darkGrey: lighten(#000, 30%);


### PR DESCRIPTION
- Darkened the 'tickets' and 'agenda' button background by 5%.
- Added subtle text shadow to all buttons to further combat low contrast.

|State|Preview|
|------|-----|
|Before|![image](https://user-images.githubusercontent.com/5493721/40102844-27397820-591e-11e8-9dbe-f25ab518bcf1.png)|
|After|![image](https://user-images.githubusercontent.com/5493721/40102770-f8734bf6-591d-11e8-986f-85aca4ee7f4a.png)|

Related issues:
https://github.com/dddwa/dddperth-website/issues/73
https://github.com/dddwa/dddperth-website/issues/55
https://github.com/dddwa/dddperth-website/issues/51