### PR TITLE
Adding support for local storage

### DIFF
--- a/components/voting.tsx
+++ b/components/voting.tsx
@@ -40,15 +40,15 @@ export default class Voting extends React.PureComponent<VotingProps, VotingState
         .map(s => s.Level)
         .unique()
         .sort(),
-      seen: [],
-      shortlist: [],
+      seen: this.readFromStorage('ddd-voting-session-seen'),
+      shortlist: this.readFromStorage('ddd-voting-session-shortlist'),
       show: 'all',
       tagFilters: [],
       tags: (this.props.sessions as Session[])
         .selectMany(s => s.Tags)
         .unique()
         .sort(),
-      votes: [],
+      votes: this.readFromStorage('ddd-voting-session-votes'),
     })
   }
 
@@ -65,11 +65,14 @@ export default class Voting extends React.PureComponent<VotingProps, VotingState
   }
 
   toggleShortlist(session: Session) {
-    this.setState({
-      shortlist: this.isInShortlist(session)
-        ? this.state.shortlist.without(session.Id)
-        : [...this.state.shortlist, session.Id],
-    })
+    this.setState(
+      {
+        shortlist: this.isInShortlist(session)
+          ? this.state.shortlist.without(session.Id)
+          : [...this.state.shortlist, session.Id],
+      },
+      () => this.writeToStorage('ddd-voting-session-shortlist', this.state.shortlist),
+    )
   }
 
   isSeen(session: Session) {
@@ -77,9 +80,12 @@ export default class Voting extends React.PureComponent<VotingProps, VotingState
   }
 
   toggleSeen(session: Session) {
-    this.setState({
-      seen: this.isSeen(session) ? this.state.seen.without(session.Id) : [...this.state.seen, session.Id],
-    })
+    this.setState(
+      {
+        seen: this.isSeen(session) ? this.state.seen.without(session.Id) : [...this.state.seen, session.Id],
+      },
+      () => this.writeToStorage('ddd-voting-session-seen', this.state.seen),
+    )
   }
 
   isVotedFor(session: Session) {
@@ -87,9 +93,28 @@ export default class Voting extends React.PureComponent<VotingProps, VotingState
   }
 
   toggleVote(session: Session) {
-    this.setState({
-      votes: this.isVotedFor(session) ? this.state.votes.without(session.Id) : [...this.state.votes, session.Id],
-    })
+    this.setState(
+      {
+        votes: this.isVotedFor(session) ? this.state.votes.without(session.Id) : [...this.state.votes, session.Id],
+      },
+      () => this.writeToStorage('ddd-voting-session-votes', this.state.votes),
+    )
+  }
+
+  writeToStorage(key: string, sessions: string[]) {
+    if (localStorage) {
+      localStorage.setItem(key, JSON.stringify(sessions))
+    }
+  }
+
+  readFromStorage(key: string) {
+    if (localStorage) {
+      const data = localStorage.getItem(key)
+      if (data != null) {
+        return JSON.parse(data)
+      }
+    }
+    return []
   }
 
   render() {

--- a/pages/vote.tsx
+++ b/pages/vote.tsx
@@ -60,11 +60,6 @@ class VotePage extends React.Component<WithPageMetadataProps, VoteState> {
           if (orderings == null) {
             const ids = JSON.stringify(sessions.map(({ Id }) => Id)) // Randomizing will be done in backend API
 
-            if (console) {
-              // tslint:disable-next-line:no-console
-              console.log('New Session Order:', ids)
-            }
-
             localStorage.setItem('ddd-voting-session-order', ids)
 
             this.setState({
@@ -72,11 +67,6 @@ class VotePage extends React.Component<WithPageMetadataProps, VoteState> {
               sessions,
             })
           } else {
-            if (console) {
-              // tslint:disable-next-line:no-console
-              console.log('Existing Session Order:', orderings)
-            }
-
             // if previous ordering data has been persisted then apply this and override API response ordering
             const indicies = new Map<string, number>(JSON.parse(orderings).map((id, index) => [id, index]))
             const preordered = sessions

--- a/pages/vote.tsx
+++ b/pages/vote.tsx
@@ -71,11 +71,11 @@ class VotePage extends React.Component<WithPageMetadataProps, VoteState> {
             const indicies = new Map<string, number>(JSON.parse(orderings).map((id, index) => [id, index]))
             const preordered = sessions
               .map(session => ({
-                Index: indicies.get(session.Id) || 0,
-                Session: session,
+                index: indicies.get(session.Id) || 0,
+                session,
               }))
-              .sort(({ Index: first }, { Index: second }) => first - second)
-              .map(({ Session: session }) => session) as Session[]
+              .sort(({ index: first }, { index: second }) => first - second)
+              .map(({ session }) => session) as Session[]
 
             this.setState({
               isLoading: false,


### PR DESCRIPTION
Added local storage support for the following use case:

- Initial order of sessions returned from the backend API on subsequent client sessions
- Shortlisted sessions
- Voted sessions
- Seen sessions