### PR TITLE
Server side rendering detection fix

### DIFF
--- a/components/voting.tsx
+++ b/components/voting.tsx
@@ -112,8 +112,12 @@ export default class Voting extends React.PureComponent<VotingProps, VotingState
     )
   }
 
+  isRunningInBrowser() {
+    return typeof window !== 'undefined'
+  }
+
   writeToStorage(key: string, value: string | string[]) {
-    if (!process && localStorage) {
+    if (this.isRunningInBrowser() && localStorage) {
       if (value instanceof String) {
         localStorage.setItem(key, value as string)
       }
@@ -122,7 +126,7 @@ export default class Voting extends React.PureComponent<VotingProps, VotingState
   }
 
   readFromStorage(key: string) {
-    if (!process && localStorage) {
+    if (this.isRunningInBrowser() && localStorage) {
       const data = localStorage.getItem(key)
       if (data != null) {
         return JSON.parse(data)

--- a/pages/vote.tsx
+++ b/pages/vote.tsx
@@ -94,9 +94,13 @@ class VotePage extends React.Component<VoteProps, VoteState> {
       })
   }
 
+  isRunningInBrowser() {
+    return typeof window !== 'undefined'
+  }
+
   setSessions(sessions: Session[]) {
-    // if the client does not support local storage then just set session state
-    if (!localStorage) {
+    // if the we're rendering on the server or the client does not support local storage then just set session state
+    if (!(this.isRunningInBrowser() && localStorage)) {
       this.setState({
         isLoading: false,
         sessions,


### PR DESCRIPTION
Fixes server side rendering detection logic error. If we were not using TypeScript using `process.browser` (which is set by Webpack) would have been preferable. I would have had to overwrite the type definition for NodeJS.Process though so felt a bit hacky.