### PR TITLE
Hide the 'Tap for session details' message when all sessions are expanded

### DIFF
--- a/components/voting.tsx
+++ b/components/voting.tsx
@@ -372,7 +372,13 @@ export default class Voting extends React.PureComponent<VotingProps, VotingState
                         <span className="badge">{tag}</span>{' '}
                       </React.Fragment>
                     ))}
-                    <small style={{ marginTop: '10px', display: 'block' }}>
+                    <small
+                      style={{
+                        display: 'block',
+                        marginTop: '10px',
+                        visibility: this.state.expandAll ? 'hidden' : 'visible',
+                      }}
+                    >
                       <span className="fa fa-plus" title="More details" /> Tap for session details
                     </small>
                     {!this.state.submitted && (


### PR DESCRIPTION
Hide the 'Tap for session details' message when the 'Show all session details' option is selected. Item expansion is disabled in this state so the message is somewhat misleading