### PR TITLE
Add title attribute to YouTube video embed iframes

### DIFF
--- a/pages/agenda/2016.tsx
+++ b/pages/agenda/2016.tsx
@@ -186,6 +186,7 @@ class Agenda2016 extends React.Component<AgendaPageProps> {
         <div className="text-center">
           <div className="responsive-video">
             <iframe
+              title="YouTube Video Player"
               width="560"
               height="315"
               src={From2016.YouTubeKeynoteEmbedUrl}
@@ -196,6 +197,7 @@ class Agenda2016 extends React.Component<AgendaPageProps> {
           </div>
           <div className="responsive-video">
             <iframe
+              title="YouTube Video Player"
               width="560"
               height="315"
               src={From2016.YouTubeLocknoteEmbedUrl}

--- a/pages/agenda/2017.tsx
+++ b/pages/agenda/2017.tsx
@@ -206,6 +206,7 @@ class Agenda2017 extends React.Component<AgendaPageProps> {
         <div className="text-center">
           <div className="responsive-video">
             <iframe
+              title="YouTube Video Player"
               width="560"
               height="315"
               src={From2017.YouTubeKeynoteEmbedUrl}
@@ -216,6 +217,7 @@ class Agenda2017 extends React.Component<AgendaPageProps> {
           </div>
           <div className="responsive-video">
             <iframe
+              title="YouTube Video Player"
               width="560"
               height="315"
               src={From2017.YouTubeLocknoteEmbedUrl}


### PR DESCRIPTION
Went with **YouTube Video Player** as I saw YouTube itself uses that as an `aria-label` on their video page and it seems to make sense from a "here is the YouTube Video Player iframe" perspective.

Updated the 2016 and 2017 agendas.

Thought about creating a "responsive-player" component as well, if that's desired? Happy to add additional commits to this PR to get that happening.

Fixes #63.