### PR TITLE
Add & use responsive video component

### DIFF
--- a/components/responsiveVideo.tsx
+++ b/components/responsiveVideo.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+import { StatelessComponent } from 'react'
+
+interface ResponsiveVideoArg {
+  src: string
+  title?: string
+}
+
+const ResponsiveVideo: StatelessComponent<ResponsiveVideoArg> = ({ src, title }) => {
+  return (
+    <div className="responsive-video">
+      <iframe
+        title={title || 'YouTube Video Player'}
+        width="560"
+        height="315"
+        src={src}
+        frameBorder="0"
+        allowFullScreen
+      />
+    </div>
+  )
+}
+
+export default ResponsiveVideo

--- a/pages/agenda/2016.tsx
+++ b/pages/agenda/2016.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Fragment } from 'react'
 import dddAgendaPage, { AgendaPageParameters, AgendaPageProps } from '../../components/dddAgendaPage'
 import withPageMetadata from '../../components/global/withPageMetadata'
+import ResponsiveVideo from '../../components/responsiveVideo'
 import Sponsors from '../../components/sponsors'
 import From2016 from '../../config/2016'
 import { SponsorType } from '../../config/types'
@@ -184,28 +185,8 @@ class Agenda2016 extends React.Component<AgendaPageProps> {
         </p>
         <h2>Media</h2>
         <div className="text-center">
-          <div className="responsive-video">
-            <iframe
-              title="YouTube Video Player"
-              width="560"
-              height="315"
-              src={From2016.YouTubeKeynoteEmbedUrl}
-              frameBorder="0"
-              allowFullScreen
-              style={{ display: 'inline-block', marginRight: '20px' }}
-            />
-          </div>
-          <div className="responsive-video">
-            <iframe
-              title="YouTube Video Player"
-              width="560"
-              height="315"
-              src={From2016.YouTubeLocknoteEmbedUrl}
-              frameBorder="0"
-              allowFullScreen
-              style={{ display: 'inline-block' }}
-            />
-          </div>
+          <ResponsiveVideo src={From2016.YouTubeKeynoteEmbedUrl} />
+          <ResponsiveVideo src={From2016.YouTubeLocknoteEmbedUrl} />
         </div>
         <p>
           <a href={From2016.YouTubePlaylistUrl} target="_blank">

--- a/pages/agenda/2017.tsx
+++ b/pages/agenda/2017.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Fragment } from 'react'
 import dddAgendaPage, { AgendaPageParameters, AgendaPageProps } from '../../components/dddAgendaPage'
 import withPageMetadata from '../../components/global/withPageMetadata'
+import ResponsiveVideo from '../../components/responsiveVideo'
 import Sponsors from '../../components/sponsors'
 import From2017 from '../../config/2017'
 import { SponsorType } from '../../config/types'
@@ -204,28 +205,8 @@ class Agenda2017 extends React.Component<AgendaPageProps> {
         <h2>Media</h2>
 
         <div className="text-center">
-          <div className="responsive-video">
-            <iframe
-              title="YouTube Video Player"
-              width="560"
-              height="315"
-              src={From2017.YouTubeKeynoteEmbedUrl}
-              frameBorder="0"
-              allowFullScreen
-              style={{ display: 'inline-block', marginRight: '20px' }}
-            />
-          </div>
-          <div className="responsive-video">
-            <iframe
-              title="YouTube Video Player"
-              width="560"
-              height="315"
-              src={From2017.YouTubeLocknoteEmbedUrl}
-              frameBorder="0"
-              allowFullScreen
-              style={{ display: 'inline-block' }}
-            />
-          </div>
+          <ResponsiveVideo src={From2017.YouTubeKeynoteEmbedUrl} />
+          <ResponsiveVideo src={From2017.YouTubeLocknoteEmbedUrl} />
         </div>
         <p>
           <a href={From2017.YouTubePlaylistUrl} target="_blank">

--- a/styles/screen.scss
+++ b/styles/screen.scss
@@ -1602,6 +1602,7 @@ tr td.highlight-session {
   width: 560px;
   height: 315px;
   position: relative;
+  vertical-align: top;
   display: inline-block;
 
   &:first-child {
@@ -1614,11 +1615,13 @@ tr td.highlight-session {
     left: 0;
     width: 100%;
     height: 100%;
+    display: inline-block;
   }
 }
 
 @media (max-width: 1199px) {
   .responsive-video:first-child {
+    margin-bottom: 10px;
     margin-right: 0;
   }
 }


### PR DESCRIPTION
As discussed in #121, I added a `ResponsiveVideo` component that takes 2 props: `src` and `title`.

After looking at the CSS I realised that there is not much point in adding `height` and `width` props because the CSS dictates the size of the container and the `iframe` already. Passing it to the `iframe` as HTML attributes therefore makes little sense.

Also tweaked the CSS a bit for nicer alignment and spacing.