### PR TITLE
Reduce heading levels inside venue map overlay

### DIFF
--- a/pages/venue.tsx
+++ b/pages/venue.tsx
@@ -68,8 +68,8 @@ class VenuePage extends React.Component<WithPageMetadataProps> {
             />
           </div>
           <div id="map-overlay">
-            <h3>{conference.Venue.Name}</h3>
-            <h4>{conference.Venue.Address}</h4>
+            <h2>{conference.Venue.Name}</h2>
+            <h3>{conference.Venue.Address}</h3>
           </div>
         </div>
         <section className="right-sidebar" id="travelinfo">

--- a/styles/screen.scss
+++ b/styles/screen.scss
@@ -1453,19 +1453,19 @@ section.full-width {
     z-index: 100;
   }
 
-  #map-overlay h3,
-  #map-overlay h4 {
+  #map-overlay h2,
+  #map-overlay h3 {
     color: #fff;
     margin: 0;
   }
 
-  #map-overlay h3 {
+  #map-overlay h2 {
     font-size: 40px;
     font-weight: 900;
     margin-top: 140px;
   }
 
-  #map-overlay h4 {
+  #map-overlay h3 {
     font-size: 24px;
     font-weight: 300;
     font-style: oblique;
@@ -1476,7 +1476,7 @@ section.full-width {
       padding: 0 2em;
     }
 
-    #map-overlay h3 {
+    #map-overlay h2 {
       margin-top: 100px;
       margin-bottom: 15px;
     }


### PR DESCRIPTION
Use h2 / h3 instead of h3 / h4 for `map-overlay` headings.

Fixes #67