### PR TITLE
Fix react warnings and errors

### DIFF
--- a/components/Keynotes.tsx
+++ b/components/Keynotes.tsx
@@ -13,7 +13,7 @@ export default ({ conference }: KeynotesProps) => (
         <div className="container">
           <h2>Keynote speakers</h2>
           {conference.Keynotes.map(keynote => (
-            <article className="keynote">
+            <article className="keynote" key={keynote.Title.replace(/ /g, '-')}>
               <h3>{keynote.Title}</h3>
               <img src={keynote.Presenters[0].ProfilePhotoUrl} alt={keynote.Presenters[0].Name} />
               <h4>

--- a/components/sessionDetails.tsx
+++ b/components/sessionDetails.tsx
@@ -20,7 +20,7 @@ const SessionDetails: React.StatelessComponent<SessionProps> = ({
   <Fragment>
     {showPresenter &&
       session.Presenters.map(p => (
-        <p key={p.Id}>
+        <p key={p.Name.replace(/ /g, '-')}>
           <img
             src={p.ProfilePhotoUrl || '/static/images/profile-image-blank.jpg'}
             alt={p.Name + ' profile photo'}
@@ -76,7 +76,7 @@ const SessionDetails: React.StatelessComponent<SessionProps> = ({
     </p>
     {showBio &&
       session.Presenters.map(p => (
-        <p className="preserve-whitespace">
+        <p key={`bio-${p.Name.replace(/ /g, '-')}`} className="preserve-whitespace">
           {session.Presenters.length > 1 && (
             <Fragment>
               <strong>{p.Name}</strong>

--- a/config/faqs.tsx
+++ b/config/faqs.tsx
@@ -35,7 +35,7 @@ export default function getFaqs(dates: Dates): FAQ[] {
 
   Faqs.push({
     Question: "[Financial Assistance] What if I can't afford to attend?",
-    Answer: (
+    AnswerWithoutParagraph: (
       <div>
         <p>
           If you can't afford the ticket price then we have Sponsored (Financial Assistance) tickets available. DDD


### PR DESCRIPTION
There 2 types of errors that came up when browsing the site:

1. `<p>` inside `<p>` / `ul` inside `<p>` in the FAQ
2. Missing or non-unique keys on the `index` page for the keynotes ([the `Id` keys have no value associated with them](https://github.com/dddwa/dddperth-website/blob/master/config/conference.ts#L185))