### PR TITLE
Fixes agenda time contrast ratio

### DIFF
--- a/styles/screen.scss
+++ b/styles/screen.scss
@@ -1595,8 +1595,8 @@ tr td.highlight-session {
 }
 
 .agenda-row .time {
-  color: #888;
   width: 85px;
+  color: #737373;
 }
 
 // Video


### PR DESCRIPTION
This fixes the contrast ratio of the time cell on the agenda page so that it's level AA compliant.
