### PR TITLE
Fixes #56

### DIFF
--- a/pages/venue.tsx
+++ b/pages/venue.tsx
@@ -45,7 +45,7 @@ class VenuePage extends React.Component<WithPageMetadataProps> {
             .
           </p>
         </div>
-        <div id="map">
+        <div id="map" aria-hidden>
           <div id="map-view">
             <GoogleMapReact
               bootstrapURLKeys={{


### PR DESCRIPTION
Adds aria-hidden to Google Map container so it isn't announced by screen readers. Fixing #56 