### PR TITLE
Fixes #172

### DIFF
--- a/components/global/meta.tsx
+++ b/components/global/meta.tsx
@@ -42,8 +42,8 @@ const Meta: StatelessComponent<MetaArgs> = ({
       <meta property="og:description" content={pageDescription || conference.SiteDescription} />
       <meta name="twitter:description" content={(pageDescription || conference.SiteDescription).substring(0, 200)} />
       <meta name="author" content={conference.Organiser.Name} />
-      <meta property="og:image" content={pageImage || '/static/images/logo-2018_.png'} />
-      <meta property="twitter:image" content={pageImage || '/static/images/logo-2018_.png'} />
+      <meta property="og:image" content={pageImage || '/static/images/logo-2019.png'} />
+      <meta property="twitter:image" content={pageImage || '/static/images/logo-2019.png'} />
       <meta name="twitter:card" content="summary" />
       <meta name="twitter:site" content={conference.Name} />
       <meta name="twitter:creator" content={conference.Organiser.Name} />


### PR DESCRIPTION
Needed to update the og:image tags to 2019. A more forward thinking fix later could be to make this part of the conference object but for now this'll make it better for anyone sharing DDD on social media.