### PR TITLE
Moves Voting Filters into a component

### DIFF
--- a/components/Voting/VotingFilters.styled.tsx
+++ b/components/Voting/VotingFilters.styled.tsx
@@ -1,0 +1,49 @@
+// tslint:disable:object-literal-sort-keys
+// tslint:disable:object-literal-key-quotes
+
+import { calcRem } from '../utils/styles/calcRem'
+import styled from '../utils/styles/theme'
+
+export const StyledTagCloudList = styled('ul')({
+  display: 'flex',
+  flexWrap: 'wrap',
+  padding: 0,
+  margin: 0,
+  listStyleType: 'none',
+
+  'li:before': {
+    content: 'normal',
+  },
+})
+
+export const StyledTagCloudInput = styled('input')(({ theme }) => ({
+  position: 'absolute',
+  clip: 'rect(0, 0, 0, 0)',
+
+  '&:checked': {
+    '& + label': {
+      background: theme.colors.tertiary,
+      color: '#fff',
+    },
+  },
+
+  '&:focus': {
+    '& + label': {
+      borderColor: theme.colors.tertiary,
+    },
+  },
+}))
+
+export const StyledTagCloudLabel = styled('label')(({ theme }) => ({
+  display: 'block',
+  padding: calcRem(5),
+  margin: calcRem(2),
+  border: '2px solid transparent',
+  cursor: 'pointer',
+  fontSize: calcRem(14),
+
+  '&:active': {
+    backgroundColor: theme.colors.tertiary,
+    color: '#fff',
+  },
+}))

--- a/components/Voting/VotingFilters.tsx
+++ b/components/Voting/VotingFilters.tsx
@@ -1,0 +1,80 @@
+import React, { useRef } from 'react'
+import ReactResponsiveSelect from 'react-responsive-select/dist/ReactResponsiveSelect'
+import { logEvent } from '../global/analytics'
+import { StyledTagCloudInput, StyledTagCloudLabel, StyledTagCloudList } from './VotingFilters.styled'
+
+interface VotingFiltersProps {
+  tags: string[]
+  levels: string[]
+  levelFilters: string[]
+  onTagFilter: (tags: string[]) => void
+  onLevelsFilter: (levels: string[]) => void
+}
+
+const OptionItem = text => (
+  <div>
+    <span className="fa fa-check-circle-o selected-marker" />
+    <span className="fa fa-circle-o not-selected-marker" />
+    <span> {text}</span>
+  </div>
+)
+
+export const VotingFilters: React.FC<VotingFiltersProps> = ({
+  tags,
+  levels,
+  levelFilters,
+  onTagFilter,
+  onLevelsFilter,
+}) => {
+  const tagCloudRef = useRef<HTMLFieldSetElement | null>(null)
+
+  return (
+    <div className="filters">
+      <em>Filter by:</em>{' '}
+      <fieldset ref={tagCloudRef} className="tag-cloud">
+        <StyledTagCloudList>
+          {tags.map(tag => (
+            <li key={tag}>
+              <StyledTagCloudInput
+                type="checkbox"
+                value={tag}
+                id={tag}
+                name={tag}
+                onChange={() => {
+                  const filteredTags = Array.from<HTMLInputElement>(
+                    tagCloudRef.current.querySelectorAll('input:checked'),
+                  ).map(input => input.value)
+
+                  if (filteredTags.length > 0) {
+                    logEvent('voting', 'tagFilter', { filter: filteredTags.join(',') })
+                  }
+
+                  onTagFilter(filteredTags)
+                }}
+              />
+              <StyledTagCloudLabel htmlFor={tag}>{tag}</StyledTagCloudLabel>
+            </li>
+          ))}
+        </StyledTagCloudList>
+      </fieldset>
+      <ReactResponsiveSelect
+        name="levelsFilter"
+        prefix="Level:"
+        options={[{ value: null, text: 'All', markup: OptionItem('All') }].concat(
+          levels.map(l => ({ value: l, text: l, markup: OptionItem(l) })),
+        )}
+        multiselect={true}
+        caretIcon={<span className="fa fa-caret-down" />}
+        onChange={selected => {
+          const newFilter = selected.options.map(o => o.value).filter(o => o !== null)
+          if (newFilter.length > 0) {
+            logEvent('voting', 'levelFilter', { filter: newFilter.join(',') })
+          }
+
+          onLevelsFilter(newFilter)
+        }}
+        selectedValues={levelFilters.length > 0 ? levelFilters : undefined}
+      />
+    </div>
+  )
+}

--- a/components/Voting/sessionPanel.styled.tsx
+++ b/components/Voting/sessionPanel.styled.tsx
@@ -74,11 +74,3 @@ export const Buttons = styled('div')(() => ({
   textAlign: 'right',
   paddingTop: '10px',
 }))
-
-// export const Icon = styled('span')(({ theme }) => ({
-
-// }))
-
-// export const Icon = styled('span')(({ theme }) => ({
-
-// }))

--- a/components/voting.tsx
+++ b/components/voting.tsx
@@ -2,13 +2,13 @@ import moment from 'moment'
 import React from 'react'
 import { DragDropContext, Draggable, Droppable, DropResult } from 'react-beautiful-dnd'
 import { Panel, PanelGroup } from 'react-bootstrap'
-import ReactResponsiveSelect from 'react-responsive-select/dist/ReactResponsiveSelect'
 import { getSessionId, logException } from '../components/global/analytics'
 import '../components/utils/arrayExtensions'
 import { SessionPanel } from '../components/Voting/sessionPanel'
 import { Session, TicketNumberWhileVoting, TicketsProvider } from '../config/types'
 import { logEvent } from './global/analytics'
 import { StyledVotingPanel } from './Voting/Voting.styled'
+import { VotingFilters } from './Voting/VotingFilters'
 
 type SessionId = Session['Id']
 type Views = 'all' | 'shortlist' | 'votes'
@@ -248,21 +248,6 @@ export default class Voting extends React.PureComponent<VotingProps, VotingState
         }
       })
 
-    const SpanIf: React.StatelessComponent<any> = ({ condition, className, children }) => (
-      <React.Fragment>
-        {condition && <span className={className}>{children}</span>}
-        {!condition && children}
-      </React.Fragment>
-    )
-
-    const option = text => (
-      <div>
-        <span className="fa fa-check-circle-o selected-marker" />
-        <span className="fa fa-circle-o not-selected-marker" />
-        <span> {text}</span>
-      </div>
-    )
-
     return (
       <React.Fragment>
         <StyledVotingPanel>
@@ -415,50 +400,17 @@ export default class Voting extends React.PureComponent<VotingProps, VotingState
         )}
 
         {this.state.show === 'all' && (
-          <div className="filters">
-            <em>Filter by:</em>{' '}
-            <fieldset className="tag-cloud">
-              <ul>
-                {this.state.tags.map(tag => (
-                  <li key={tag}>
-                    <input
-                      type="checkbox"
-                      value={tag}
-                      id={tag}
-                      name={tag}
-                      onChange={selected => {
-                        const newFilter = Array.from(document.querySelectorAll('.tag-cloud input:checked'))
-                          .map(o => o.value)
-                          .filter(o => o !== null)
-                        if (newFilter.length > 0) {
-                          logEvent('voting', 'tagFilter', { filter: newFilter.join(',') })
-                        }
-                        this.setState({ tagFilters: newFilter })
-                      }}
-                    />
-                    <label htmlFor={tag}>{tag}</label>
-                  </li>
-                ))}
-              </ul>
-            </fieldset>
-            <ReactResponsiveSelect
-              name="levelsFilter"
-              prefix="Level:"
-              options={[{ value: null, text: 'All', markup: option('All') }].concat(
-                this.state.levels.map(l => ({ value: l, text: l, markup: option(l) })),
-              )}
-              multiselect={true}
-              caretIcon={<span className="fa fa-caret-down" />}
-              onChange={selected => {
-                const newFilter = selected.options.map(o => o.value).filter(o => o !== null)
-                if (newFilter.length > 0) {
-                  logEvent('voting', 'levelFilter', { filter: newFilter.join(',') })
-                }
-                this.setState({ levelFilters: newFilter })
-              }}
-              selectedValues={this.state.levelFilters.length > 0 ? this.state.levelFilters : undefined}
-            />
-          </div>
+          <VotingFilters
+            tags={this.state.tags}
+            levels={this.state.levels}
+            levelFilters={this.state.levelFilters}
+            onTagFilter={tags => {
+              this.setState({ tagFilters: tags })
+            }}
+            onLevelsFilter={levels => {
+              this.setState({ levelFilters: levels })
+            }}
+          />
         )}
 
         <DragDropContext

--- a/styles/screen.scss
+++ b/styles/screen.scss
@@ -1037,11 +1037,8 @@ section.full-width {
   .submit-block {
     float: right;
   }
-
-  
 }
 #voting-interface {
-  
   .panel-heading {
     .status {
       float: right;
@@ -1131,58 +1128,6 @@ section.full-width {
   .rrs__option.rrs__option--selected,
   .rrs--has-changed .rrs__label {
     color: $primary-color;
-  }
-
-  .tag-cloud {
-    ul {
-      display: flex;
-      flex-wrap: wrap;
-      list-style-type: none;
-      margin: 0;
-      padding: 0;
-    }
-
-    li {
-      &:before {
-        content: normal;
-      }
-    }
-
-    input {
-      position: absolute;
-      left: -200vw;
-
-      &:checked {
-        & + label {
-          background: $voting;
-          color: #fff;
-        }
-      }
-
-      &:focus {
-        & + label {
-          border-color: $voting;
-        }
-      }
-    }
-
-    label {
-      border: 2px solid transparent;
-      cursor: pointer;
-      display: block;
-      font-size: 0.9em;
-      margin: 2px;
-      padding: 5px;
-
-      &:active {
-        background: $voting;
-        color: #fff;
-      }
-
-      &:hover,
-      &:focus {
-      }
-    }
   }
 }
 .btn.flagged {


### PR DESCRIPTION
This moves the voting filters into a component to try and make voting
component a little more digestable.

Moved the styling of tag cloud into Emotion and removed the reliance of
the functionality from a class name, opting instead for useRef