### PR TITLE
Adds up next to agenda

### DIFF
--- a/components/Agenda/Agenda.styled.tsx
+++ b/components/Agenda/Agenda.styled.tsx
@@ -111,3 +111,15 @@ export const StyledFeedbackActions = styled('div')({
     marginRight: calcRem(10),
   },
 })
+export const StyledUpNext = styled('div')(({ theme }) => ({
+  marginBottom: calcRem(20),
+
+  '& > h2': {
+    padding: calcRem(10),
+    margin: 0,
+    backgroundColor: theme.colors.inverse,
+    color: '#fff',
+    fontSize: calcRem(20),
+  },
+}))
+StyledUpNext.displayName = 'StyledUpNext'

--- a/components/Agenda/Agenda.tsx
+++ b/components/Agenda/Agenda.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment, useState } from 'react'
 import { Session, Sponsor } from '../../config/types'
 import { SafeLink } from '../global/safeLink'
+import { SessionGroup, useSessionGroups } from '../utils/useSessionGroups'
 import { useSessions } from '../utils/useSessions'
 import { StyledCenteredParagraph, StyledSponsorLogo } from './Agenda.styled'
 import { SessionDetails } from './SessionDetails'
@@ -13,11 +14,12 @@ interface AgendaProps {
   sessionsUrl: string
   acceptingFeedback: boolean
   feedbackLink?: string
-  render: (sessions: Session[], onSelect: onSelectCallback) => React.ReactElement
+  render: (sessions: Session[], nextSessionGroup: SessionGroup, onSelect: onSelectCallback) => React.ReactElement
 }
 
 export const Agenda: React.FC<AgendaProps> = props => {
   const { isError, sessions } = useSessions(props.sessionsUrl, props.sessions)
+  const { nextSessionGroup } = useSessionGroups(sessions)
   const [showModal, setShowModal] = useState(false)
   const [selectedSession, setSelectedSession] = useState<Session | undefined>()
   const [sessionSponsor, setSessionSponsor] = useState<Sponsor | undefined>()
@@ -34,7 +36,7 @@ export const Agenda: React.FC<AgendaProps> = props => {
 
   return (
     <React.Fragment>
-      {props.render(sessions, onSelectHandler)}
+      {props.render(sessions, nextSessionGroup, onSelectHandler)}
 
       <StyledDialogOverlay isOpen={showModal} onDismiss={() => setShowModal(false)}>
         <StyledDialogContent>

--- a/components/Agenda/AgendaSession.tsx
+++ b/components/Agenda/AgendaSession.tsx
@@ -13,6 +13,7 @@ interface AgendaSessionProps {
   sessionId?: string
   children?: React.ReactNode
   room?: number | string
+  alwaysShowRoom?: boolean
   sponsorId?: string
   fullWidth?: boolean
   isKeynote?: boolean
@@ -24,6 +25,7 @@ export const AgendaSession: React.FC<AgendaSessionProps> = ({
   sessionId,
   children,
   room,
+  alwaysShowRoom,
   sponsorId,
   fullWidth,
   isKeynote,
@@ -51,14 +53,14 @@ export const AgendaSession: React.FC<AgendaSessionProps> = ({
             <StyledAgendaTitle isKeynote={isKeynote}>{session.Title}</StyledAgendaTitle>
           )}
           {sponsor && <StyledSponsor>Sponsored by: {sponsor.shortName || sponsor.name}</StyledSponsor>}
-          {typeof room !== 'undefined' && <StyledRoom showOnMobile={!isKeynote}>{getRoom(room)}</StyledRoom>}
+          {typeof room !== 'undefined' && <StyledRoom showOnMobile={!alwaysShowRoom}>{getRoom(room)}</StyledRoom>}
         </StyledAgendaButton>
       )}
       {children && (
         <Fragment>
           {children}
           {typeof room !== 'undefined' && (
-            <StyledRoom showOnMobile={session !== false && !isKeynote}>{getRoom(room)}</StyledRoom>
+            <StyledRoom showOnMobile={session !== false && !alwaysShowRoom}>{getRoom(room)}</StyledRoom>
           )}
         </Fragment>
       )}

--- a/components/currentAgenda.tsx
+++ b/components/currentAgenda.tsx
@@ -11,6 +11,7 @@ import {
   StyledAgendaRowList,
   StyledFeedbackActions,
   StyledTrackHeader,
+  StyledUpNext,
 } from './Agenda/Agenda.styled'
 import { AgendaProvider } from './Agenda/AgendaContext'
 import { AgendaSession } from './Agenda/AgendaSession'
@@ -57,7 +58,7 @@ export const CurrentAgenda: React.FC<CurrentAgendaProps> = ({
         sessionsUrl={sessionsUrl}
         acceptingFeedback={acceptingFeedback}
         feedbackLink={feedbackLink}
-        render={(agendaSessions, onSelect) => {
+        render={(agendaSessions, nextSessionGroup, onSelect) => {
           return (
             <AgendaProvider
               onSelect={onSelect}
@@ -65,6 +66,22 @@ export const CurrentAgenda: React.FC<CurrentAgendaProps> = ({
               sponsors={sponsors}
               rooms={['Theatre', 'RR5', 'M6', 'M7', 'M8', 'M9']}
             >
+              {Conference.ShowNextSessions && nextSessionGroup && nextSessionGroup.sessions.length > 0 && (
+                <StyledUpNext>
+                  <h2>Up next</h2>
+                  <StyledAgendaRow>
+                    <AgendaTime time={nextSessionGroup.timeStart.clone()} />
+                    {nextSessionGroup.sessions.map(session => (
+                      <AgendaSession
+                        key={session.Id}
+                        sessionId={session.Id}
+                        fullWidth={nextSessionGroup.sessions.length === 1}
+                      />
+                    ))}
+                  </StyledAgendaRow>
+                </StyledUpNext>
+              )}
+
               <StyledAgendaRowList>
                 <li>Time</li>
                 <li>Theatre</li>

--- a/components/currentAgenda.tsx
+++ b/components/currentAgenda.tsx
@@ -64,18 +64,20 @@ export const CurrentAgenda: React.FC<CurrentAgendaProps> = ({
               onSelect={onSelect}
               sessions={agendaSessions}
               sponsors={sponsors}
-              rooms={['Theatre', 'RR5', 'M6', 'M7', 'M8', 'M9']}
+              rooms={Conference.RoomNames}
             >
               {Conference.ShowNextSessions && nextSessionGroup && nextSessionGroup.sessions.length > 0 && (
                 <StyledUpNext>
                   <h2>Up next</h2>
                   <StyledAgendaRow>
                     <AgendaTime time={nextSessionGroup.timeStart.clone()} />
-                    {nextSessionGroup.sessions.map(session => (
+                    {nextSessionGroup.sessions.map((session, index) => (
                       <AgendaSession
                         key={session.Id}
                         sessionId={session.Id}
                         fullWidth={nextSessionGroup.sessions.length === 1}
+                        room={index}
+                        alwaysShowRoom={true}
                       />
                     ))}
                   </StyledAgendaRow>
@@ -93,7 +95,7 @@ export const CurrentAgenda: React.FC<CurrentAgendaProps> = ({
               </StyledAgendaRowList>
               <StyledAgendaRow>
                 <AgendaTime time={date.clone()} />
-                <AgendaSession room="Riverside Foyer (Level 2)" fullWidth>
+                <AgendaSession room="Riverside Foyer (Level 2)" alwaysShowRoom fullWidth>
                   <StyledTrackHeader>Registration</StyledTrackHeader>
                   <StyledAddress>
                     Perth Convention and Exhibition Centre
@@ -104,13 +106,13 @@ export const CurrentAgenda: React.FC<CurrentAgendaProps> = ({
               </StyledAgendaRow>
               <StyledAgendaRow>
                 <AgendaTime time={date.clone().set({ minutes: 45 })} />
-                <AgendaSession room="Riverside Theatre" fullWidth>
+                <AgendaSession room="Riverside Theatre" alwaysShowRoom fullWidth>
                   <StyledTrackHeader>Welcome and housekeeping</StyledTrackHeader>
                 </AgendaSession>
               </StyledAgendaRow>
               <StyledAgendaRow>
                 <AgendaTime time={date.clone().set('hour', 9)} />
-                <AgendaSession room="Riverside Theatre" fullWidth>
+                <AgendaSession room="Riverside Theatre" alwaysShowRoom fullWidth>
                   <StyledTrackHeader>Welcome to country</StyledTrackHeader>
                 </AgendaSession>
               </StyledAgendaRow>
@@ -125,6 +127,7 @@ export const CurrentAgenda: React.FC<CurrentAgendaProps> = ({
                   )}
                   fullWidth
                   isKeynote
+                  alwaysShowRoom
                 />
               </StyledAgendaRow>
               <StyledAgendaRow>
@@ -144,7 +147,7 @@ export const CurrentAgenda: React.FC<CurrentAgendaProps> = ({
               </StyledAgendaRow>
               <StyledAgendaRow>
                 <AgendaTime time={date.clone().set({ hour: 10, minute: 25 })} />
-                <AgendaSession room="Riverside Foyer and South Foyer" fullWidth>
+                <AgendaSession room="Riverside Foyer and South Foyer" alwaysShowRoom fullWidth>
                   <StyledTrackHeader>Morning tea</StyledTrackHeader>
                 </AgendaSession>
               </StyledAgendaRow>
@@ -189,7 +192,7 @@ export const CurrentAgenda: React.FC<CurrentAgendaProps> = ({
               </StyledAgendaRow>
               <StyledAgendaRow>
                 <AgendaTime time={date.clone().set({ hour: 13, minute: 5 })} />
-                <AgendaSession room="Riverside Foyer and South Foyer" fullWidth>
+                <AgendaSession room="Riverside Foyer and South Foyer" alwaysShowRoom fullWidth>
                   <StyledTrackHeader>Lunch</StyledTrackHeader>
                 </AgendaSession>
               </StyledAgendaRow>
@@ -219,13 +222,13 @@ export const CurrentAgenda: React.FC<CurrentAgendaProps> = ({
               </StyledAgendaRow>
               <StyledAgendaRow>
                 <AgendaTime time={date.clone().set({ hour: 15, minute: 20 })} />
-                <AgendaSession room="Riverside Foyer and South Foyer" fullWidth>
+                <AgendaSession room="Riverside Foyer and South Foyer" alwaysShowRoom fullWidth>
                   <StyledTrackHeader>Afternoon tea</StyledTrackHeader>
                 </AgendaSession>
               </StyledAgendaRow>
               <StyledAgendaRow>
                 <AgendaTime time={date.clone().set({ hour: 15, minute: 50 })} />
-                <AgendaSession room="Riverside Theatre" fullWidth>
+                <AgendaSession room="Riverside Theatre" alwaysShowRoom fullWidth>
                   <StyledTrackHeader>Prize Draw</StyledTrackHeader>
                 </AgendaSession>
               </StyledAgendaRow>
@@ -238,11 +241,12 @@ export const CurrentAgenda: React.FC<CurrentAgendaProps> = ({
                   renderPresenters={presenters => <StyledAgendaPresenter>Locknote: {presenters}</StyledAgendaPresenter>}
                   fullWidth
                   isKeynote
+                  alwaysShowRoom
                 />
               </StyledAgendaRow>
               <StyledAgendaRow>
                 <AgendaTime time={date.clone().set({ hour: 17, minute: 5 })} />
-                <AgendaSession room="Riverside Theatre" fullWidth>
+                <AgendaSession room="Riverside Theatre" alwaysShowRoom fullWidth>
                   <StyledTrackHeader>Thank yous and wrap up</StyledTrackHeader>
                 </AgendaSession>
               </StyledAgendaRow>
@@ -251,7 +255,7 @@ export const CurrentAgenda: React.FC<CurrentAgendaProps> = ({
                   time={date.clone().set({ hour: 17, minute: 10 })}
                   endTime={date.clone().set({ hour: 19, minute: 0 })}
                 />
-                <AgendaSession room="Riverside Foyer and South Foyer" fullWidth>
+                <AgendaSession room="Riverside Foyer and South Foyer" alwaysShowRoom fullWidth>
                   <StyledTrackHeader>Afterparty</StyledTrackHeader>
                 </AgendaSession>
               </StyledAgendaRow>

--- a/components/utils/useSessionGroups.ts
+++ b/components/utils/useSessionGroups.ts
@@ -32,7 +32,20 @@ interface SessionGroups {
 }
 
 function getSessionById(sessions: Session[], ids: SessionId[]) {
-  return sessions.filter(session => ids.includes(session.Id))
+  return sessions
+    .filter(session => ids.includes(session.Id))
+    .sort((sessionA, sessionB) => {
+      const aIndex = ids.indexOf(sessionA.Id)
+      const bIndex = ids.indexOf(sessionB.Id)
+
+      if (aIndex < bIndex) {
+        return -1
+      } else if (aIndex > bIndex) {
+        return 1
+      } else {
+        return 0
+      }
+    })
 }
 
 // so manual - ideally there would be a better way to achieve this or expand it to handle the agenda too

--- a/config/conference.ts
+++ b/config/conference.ts
@@ -138,6 +138,7 @@ const Conference: IConference = {
   HideSponsorshipUpsell: true,
   HideVenue: venue === null,
   HideAfterpartyVenue: venue === null || venue.Afterparty === null,
+  ShowNextSessions: true,
 
   Venue: venue,
 

--- a/config/conference.ts
+++ b/config/conference.ts
@@ -234,6 +234,8 @@ const Conference: IConference = {
     },
   ],
 
+  RoomNames: ['Theatre', 'RR5', 'M6', 'M7', 'M8', 'M9'],
+
   SessionGroups: [
     {
       sessions: ['112b54cc-df00-40fd-ad5e-4b0714329821'],

--- a/config/types.ts
+++ b/config/types.ts
@@ -66,6 +66,7 @@ export interface Conference {
   HideSponsorshipUpsell: boolean
   HideVenue: boolean
   HideAfterpartyVenue: boolean
+  ShowNextSessions: boolean
 
   Socials: Socials
 

--- a/config/types.ts
+++ b/config/types.ts
@@ -79,6 +79,9 @@ export interface Conference {
   Sponsors: Sponsor[]
 
   Keynotes: Session[]
+
+  RoomNames: string[]
+
   SessionGroups: SessionGroupWithIds[]
 }
 

--- a/pages/feedback.tsx
+++ b/pages/feedback.tsx
@@ -51,12 +51,7 @@ const Feedback: NextSFC<FeedbackMetadataProps> = ({ pageMetadata, ssrSessions })
   const conference = pageMetadata.conference
   const { deviceId } = useDeviceId(conference.Instance)
   const { sessions, isError, isLoaded } = useSessions(pageMetadata.appConfig.getAgendaUrl, ssrSessions)
-  const { allSessionGroups, ...sessionGroups } = useSessionGroups(
-    conference.Date.clone(),
-    conference.EndDate.clone(),
-    sessions,
-    conference.SessionGroups,
-  )
+  const { allSessionGroups, ...sessionGroups } = useSessionGroups(sessions)
   const [formState, dispatch] = useReducer(formReducer, defaultFormState)
   const hasPreviousSessions =
     sessions && sessionGroups.previousSessionGroup && sessionGroups.previousSessionGroup.sessions.length > 0


### PR DESCRIPTION
Applying useSessionGroups to the Agenda page, we could have the next talks
at the top of the agenda to make it quick and easy to look on the day.

How it looks:
![up next](https://user-images.githubusercontent.com/1066856/62210972-fa45ee80-b3cf-11e9-853b-269e8759d99d.png)

