### PR TITLE
Chore: Remove global UL/OL styling

### DIFF
--- a/components/Agenda/Agenda.styled.tsx
+++ b/components/Agenda/Agenda.styled.tsx
@@ -58,6 +58,7 @@ export const StyledAgendaRowList = styled('ul')(({ theme }) => ({
   display: 'none',
   margin: 0,
   backgroundColor: theme.colors.inverse,
+  listStyle: 'none',
 
   li: {
     backgroundColor: theme.colors.secondary,
@@ -65,10 +66,6 @@ export const StyledAgendaRowList = styled('ul')(({ theme }) => ({
     fontSize: calcRem(20),
     fontWeight: theme.weights.bold,
     textAlign: 'center',
-  },
-
-  'li::before': {
-    content: 'none',
   },
 
   [breakpoint('sm')]: {

--- a/components/Feedback/FeedbackTimeTesting.tsx
+++ b/components/Feedback/FeedbackTimeTesting.tsx
@@ -9,7 +9,7 @@ interface FeedbackTimeTestingProps {
 export const FeedbackTimeTesting: React.FC<FeedbackTimeTestingProps> = ({ sessionGroups }) => (
   <Alert kind="warning">
     <p>Testing component. Times are start/end of session groups</p>
-    <ul>
+    <ul style={{ listStyle: 'none' }}>
       {sessionGroups.map(sessionGroup => (
         <li key={sessionGroup.timeStart.valueOf()}>
           <button type="button" onClick={() => dateTimeProvider.setDateTo(sessionGroup.timeStart)}>

--- a/components/ImportantDatesList/ImportantDate.styled.ts
+++ b/components/ImportantDatesList/ImportantDate.styled.ts
@@ -28,6 +28,7 @@ interface LayoutProp {
 }
 
 export const StyledImportantDateList = styled('ul')<LayoutProp>(({ layout }) => ({
+  listStyle: 'none',
   ...conditionalStyles(layout === 'calendar', {
     display: 'flex',
     flexWrap: 'wrap',
@@ -118,10 +119,6 @@ export const StyledImportantDateInline = styled('li', {
   borderWidth: 0,
   borderRight: `${ImportantDateBorderWidth}px solid ${dateBorderColor(theme, dateType)}`,
   textAlign: 'left',
-
-  '&::before': {
-    content: 'none',
-  },
 }))
 
 interface StyledImportantDateContentProps {

--- a/components/Voting/VotingFilters.styled.tsx
+++ b/components/Voting/VotingFilters.styled.tsx
@@ -10,10 +10,6 @@ export const StyledTagCloudList = styled('ul')({
   padding: 0,
   margin: 0,
   listStyleType: 'none',
-
-  'li:before': {
-    content: 'normal',
-  },
 })
 
 export const StyledTagCloudInput = styled('input')(({ theme }) => ({

--- a/components/eventDetailsSummary.tsx
+++ b/components/eventDetailsSummary.tsx
@@ -1,6 +1,7 @@
 import React, { StatelessComponent } from 'react'
 import { Action, Conference, Dates, TicketPurchasingOptions } from '../config/types'
 import ActionButton from './actionButton'
+import { StyledList } from './global/text'
 
 export interface EventDetailsSummaryProps {
   conference: Conference
@@ -17,9 +18,9 @@ const EventDetailsSummary: StatelessComponent<EventDetailsSummaryProps> = ({
 }) => (
   <div className="event-details">
     <h2>
-      <span>{!dates.IsComplete ? 'Next event' : 'Previous event'}</span> {dates.Display}
+      <span>{!dates.IsComplete ? 'Next event' : 'Previous event'}</span> <time>{dates.Display}</time>
     </h2>
-    <ul>
+    <StyledList>
       {conference.TicketPurchasingOptions === TicketPurchasingOptions.SoldOut && (
         <li>
           <strong>SOLD OUT</strong>
@@ -34,7 +35,7 @@ const EventDetailsSummary: StatelessComponent<EventDetailsSummaryProps> = ({
         <li key={i}>{point}</li>
       ))}
       <li>Only {conference.TicketPrice}</li>
-    </ul>
+    </StyledList>
     {pagePath !== primaryAction.Url && <ActionButton action={primaryAction} />}
   </div>
 )

--- a/components/global/text.ts
+++ b/components/global/text.ts
@@ -1,0 +1,18 @@
+// tslint:disable: object-literal-sort-keys
+import { calcRem } from '../utils/styles/calcRem'
+import styled from '../utils/styles/theme'
+
+export const StyledList = styled('ul')(({ theme }) => ({
+  paddingLeft: calcRem(14),
+
+  li: {
+    paddingLeft: calcRem(4),
+    listStyleImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath fill='${theme.colors.primary.replace(
+      '#',
+      '%23',
+    )}' d='M0 0h6v6H0z'/%3E%3C/svg%3E")`,
+    listStyleType: 'none',
+  },
+}))
+
+export const StyledOrderedList = StyledList.withComponent('ol')

--- a/config/faqs.tsx
+++ b/config/faqs.tsx
@@ -1,6 +1,7 @@
 // tslint:disable:object-literal-sort-keys
 import React, { Fragment } from 'react'
 import { SafeLink } from '../components/global/safeLink'
+import { StyledList } from '../components/global/text'
 import Conference from './conference'
 import { Dates, FAQ, TicketPurchasingOptions, TicketsProvider } from './types'
 
@@ -23,13 +24,9 @@ export default function getFaqs(dates: Dates): FAQ[] {
 
   Faqs.push({
     Question: 'How much does it cost to attend?',
-    Answer: `${
-      Conference.TicketPrice
-    } covers your entry, food and coffee all day and access to the afterparty! Amazing value right!?
+    Answer: `${Conference.TicketPrice} covers your entry, food and coffee all day and access to the afterparty! Amazing value right!?
       We are able to keep the ticket price so low thanks to our generous sponsors.
-      ${
-        Conference.Name
-      } is a non profit event and any excess will be kept as part of a fund for future events and/or donated to charity.`,
+      ${Conference.Name} is a non profit event and any excess will be kept as part of a fund for future events and/or donated to charity.`,
     Category: 'tickets',
   })
 
@@ -65,7 +62,7 @@ export default function getFaqs(dates: Dates): FAQ[] {
           )}
           .
         </p>
-        <ul>
+        <StyledList>
           <li>Already attended a conference in the past? That's ok.</li>
           <li>Already received a sponsored ticket in the past? Still ok.</li>
           <li>
@@ -73,7 +70,7 @@ export default function getFaqs(dates: Dates): FAQ[] {
           </li>
           <li>Don't want to take money away from someone else? Really, it’s ok, everyone says that!</li>
           <li>Don't feel like you deserve this? That’s also ok: you do.</li>
-        </ul>
+        </StyledList>
       </div>
     ),
     Category: 'tickets',
@@ -112,9 +109,7 @@ export default function getFaqs(dates: Dates): FAQ[] {
 
   Faqs.push({
     Question: 'Will childcare be available?',
-    Answer: `Yes! We will be providing childcare at this year’s conference. It will be available for the duration of the main conference (not including the afterparty) and will cost ${
-      Conference.ChildcarePrice
-    }. You will be required to provide food for your child for the day. If you would like to book your child in then please purchase an additional ‘Childcare’ ticket when purchasing your ticket. Spots are limited!`,
+    Answer: `Yes! We will be providing childcare at this year’s conference. It will be available for the duration of the main conference (not including the afterparty) and will cost ${Conference.ChildcarePrice}. You will be required to provide food for your child for the day. If you would like to book your child in then please purchase an additional ‘Childcare’ ticket when purchasing your ticket. Spots are limited!`,
     Category: 'tickets',
   })
 
@@ -247,7 +242,7 @@ export default function getFaqs(dates: Dates): FAQ[] {
     AnswerWithoutParagraph: (
       <Fragment>
         <p>Perth has a very active software community. Consider attending one of the meetups/conferences such as:</p>
-        <ul>
+        <StyledList>
           <li>
             <SafeLink href="http://www.meetup.com/PerthDotNet/" target="_blank">
               Perth .NET
@@ -313,7 +308,7 @@ export default function getFaqs(dates: Dates): FAQ[] {
               Yow! West conference
             </SafeLink>
           </li>
-        </ul>
+        </StyledList>
         <p>
           Furthermore, you can see an up to date list of Australian conferences at{' '}
           <SafeLink href="https://github.com/readify/devevents" target="_blank">
@@ -333,7 +328,7 @@ export default function getFaqs(dates: Dates): FAQ[] {
           {Conference.Name} is organised by DDD WA Inc. a non-profit organisation set up to create inclusive events for
           the WA software community. {Conference.Name} {Conference.Instance} is organised by:
         </p>
-        <ul>
+        <StyledList>
           <li>
             <SafeLink href="https://www.linkedin.com/in/rebeccacwaters/" target="_blank">
               Rebecca Waters
@@ -424,7 +419,7 @@ export default function getFaqs(dates: Dates): FAQ[] {
               Priyaj Sham Chukoury
             </SafeLink>
           </li>
-        </ul>
+        </StyledList>
         <p>
           <SafeLink href="https://blog.dddperth.com/meet-the-2019-ddd-perth-team-d45cec7f5539" target="_blank">
             Meet the team

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import React from 'react'
 import { SafeLink } from '../components/global/safeLink'
+import { StyledList } from '../components/global/text'
 import withPageMetadata, { WithPageMetadataProps } from '../components/global/withPageMetadata'
 import Page from '../layouts/withSidebar'
 
@@ -10,13 +11,13 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
     <p>
       {props.pageMetadata.conference.TagLine}. {props.pageMetadata.conference.Goal} We do this by:
     </p>
-    <ul>
+    <StyledList>
       <li>Making the ticket price as low as possible ({props.pageMetadata.conference.TicketPrice})</li>
       <li>Running the event on a Saturday</li>
       <li>Allowing anyone to submit about any software industry related topic</li>
       <li>Having a democratically chosen agenda</li>
       <li>Focussing on creating a safe and inclusive environment where everyone is welcome</li>
-    </ul>
+    </StyledList>
     <p className="text-center">
       <img src="/static/images/logo.png" alt="DDD Perth logo" style={{ width: '250px' }} />
       <img src="/static/images/logo-2019.png" alt="DDD Perth 2019 logo" style={{ width: '250px' }} />
@@ -35,13 +36,13 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
       </SafeLink>{' '}
       or any other activities are used for:
     </p>
-    <ul>
+    <StyledList>
       <li>Running current, or future, DDD Perth or DDD By Night events</li>
       <li>
         Sponsoring events or meetup groups in the WA software industry that align to the purpose and goals of DDD Perth
       </li>
       <li>Other activities that contribute to the WA software industry and align to our purpose and goals</li>
-    </ul>
+    </StyledList>
     <h2>What does DDD stand for?</h2>
     <p>
       DDD Perth started out its life as part of the Developer! Developer! Developer! series of events and while our
@@ -62,8 +63,8 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
       and{' '}
       <SafeLink href="https://blog.dddperth.com/meet-the-team-35865433cb39" target="_blank">
         since 2018 it has been run by DDD WA Inc.
-      </SafeLink>.{' '}
-      We are now in our fifth year, which we think is worth celebrating!{' '}
+      </SafeLink>
+      . We are now in our fifth year, which we think is worth celebrating!{' '}
       <SafeLink href="https://blog.dddperth.com/meet-the-2019-ddd-perth-team-d45cec7f5539" target="_blank">
         Meet this year's team.
       </SafeLink>
@@ -73,7 +74,7 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
       <img src="/static/images/logo-old.png" alt="DDD Perth logo" style={{ width: '250px' }} />
     </p>
     <p>DDD Perth has been held on the following dates:</p>
-    <ul>
+    <StyledList>
       <li>
         <Link href="/agenda/2015">
           <a>29 August 2015 @ Burswood on Swan - 100 attendees</a>
@@ -94,7 +95,7 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
           <a>4 August 2018 @ Perth Convention and Exhibition Centre - 470 attendees (510 tickets sold)</a>
         </Link>
       </li>
-    </ul>
+    </StyledList>
     <p>
       Developer! Developer! Developer! started in 2005 in the United Kingdom as a community conference organised by
       software developers for software developers.{' '}
@@ -104,12 +105,12 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
       .
     </p>
     <p>DDD was set up with a number of key elements in mind, which hold true for all DDD conferences held worlwide:</p>
-    <ul>
+    <StyledList>
       <li>It is free / low cost</li>
       <li>It is on a Saturday</li>
       <li>An open submissions process</li>
       <li>A democratically chosen agenda</li>
-    </ul>
+    </StyledList>
     <h2>Sister events</h2>
     <p>We have a number of sister events across Australia:</p>
     <p className="text-center">

--- a/pages/cfp.tsx
+++ b/pages/cfp.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import Router from 'next/router'
 import React from 'react'
 import { SafeLink } from '../components/global/safeLink'
+import { StyledList } from '../components/global/text'
 import withPageMetadata, { WithPageMetadataProps } from '../components/global/withPageMetadata'
 import dateTimeProvider from '../components/utils/dateTimeProvider'
 import Conference from '../config/conference'
@@ -49,7 +50,7 @@ class CFPPage extends React.Component<WithPageMetadataProps> {
         </p>
 
         <p>We want to encourage people that wouldn't normally speak at conferences to give it a go! We do this by:</p>
-        <ul>
+        <StyledList>
           <li>
             Having an enforced{' '}
             <Link href="/code-of-conduct">
@@ -84,14 +85,15 @@ class CFPPage extends React.Component<WithPageMetadataProps> {
             any ideas you have or give safe and constructive feedback.
           </li>
           <li>
-            There will also be <strong>free speaker training and support</strong> for all speakers, so <strong>first timers, juniors, and
-            everyone else</strong> are all encouraged to submit and will have support!
+            There will also be <strong>free speaker training and support</strong> for all speakers, so{' '}
+            <strong>first timers, juniors, and everyone else</strong> are all encouraged to submit and will have
+            support!
           </li>
           <li>
             Allowing speakers to opt out of question &amp; answer time at the end of their presentation if they don't
             feel comfortable doing it.
           </li>
-        </ul>
+        </StyledList>
 
         <p>
           This year we are using Sessionize to track submissions - this provides a great experience for speakers since
@@ -100,7 +102,7 @@ class CFPPage extends React.Component<WithPageMetadataProps> {
         </p>
 
         <p>Other things to note for presenters:</p>
-        <ul>
+        <StyledList>
           <li>
             Speakers get free entry into the event; flights and accommodation for speakers are not normally covered
             (outside of keynote speakers), but if that's a limitation that stops you from speaking then please{' '}
@@ -127,7 +129,7 @@ class CFPPage extends React.Component<WithPageMetadataProps> {
             </a>{' '}
             and we'll get right back to you :)
           </li>
-        </ul>
+        </StyledList>
 
         <p className="text-center">
           <SafeLink className="btn content" target="_blank" href={conference.SessionizeUrl}>

--- a/pages/code-of-conduct.tsx
+++ b/pages/code-of-conduct.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { StyledList } from '../components/global/text'
 import withPageMetadata, { WithPageMetadataProps } from '../components/global/withPageMetadata'
 import Page from '../layouts/withSidebar'
 
@@ -28,7 +29,7 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
 
     <p>Harassment includes, but is not limited to:</p>
 
-    <ul>
+    <StyledList>
       <li>
         Verbal or written comments that reinforce social structures of domination related to gender, gender identity and
         expression, sexual orientation, disability, physical appearance, body size, race, age, religion
@@ -40,7 +41,7 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
       <li>Inappropriate physical contact</li>
       <li>Unwelcome sexual attention</li>
       <li>Advocating for, or encouraging, any of the above behaviour</li>
-    </ul>
+    </StyledList>
 
     <h2>Need Help?</h2>
 
@@ -56,7 +57,7 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
 
     <p>You can make a personal report by:</p>
 
-    <ul>
+    <StyledList>
       <li>
         Contacting a staff member, identified by {props.pageMetadata.conference.Organiser.ShirtColour} event branded
         t-shirts and organiser name tags
@@ -77,7 +78,7 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
           {props.pageMetadata.conference.Socials.Email}
         </a>
       </li>
-    </ul>
+    </StyledList>
 
     <p>
       Emails and Twitter direct messages will be monitored by our media officer{' '}
@@ -107,7 +108,7 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
 
     <h3>Important contact numbers</h3>
 
-    <ul>
+    <StyledList>
       <li>
         <strong>Police:</strong>{' '}
         <a href={props.pageMetadata.conference.ImportantContacts.Police.MapUrl}>
@@ -130,13 +131,13 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
           {props.pageMetadata.conference.ImportantContacts.NonEmergencyMedical.Details}
         </a>
       </li>
-    </ul>
+    </StyledList>
 
     <h2>Enforcement</h2>
 
     <p>Participants asked to stop any harassing behaviour are expected to:</p>
 
-    <ul>
+    <StyledList>
       <li>
         Listen to the complaint with an open mind and consider the effect rather than intent of the behaviour in
         question
@@ -144,7 +145,7 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
       <li>Not be dismissive of the complainant</li>
       <li>Understand any advice given on how to act in the future</li>
       <li>Comply with the directions of the {props.pageMetadata.conference.Name} organisers</li>
-    </ul>
+    </StyledList>
 
     <p>
       If a participant engages in harassing behaviour, event organisers retain the right to take any actions to keep the
@@ -199,14 +200,14 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
 
     <p>We will have colored lanyards for attendees to indicate their comfort level with being photographed:</p>
 
-    <ul>
+    <StyledList>
       <li>
         <strong>Black:</strong> fine to photograph
       </li>
       <li>
         <strong>Red:</strong> do not photograph
       </li>
-    </ul>
+    </StyledList>
 
     <p>In case of any doubt, please ask before taking photographs of attendees, speakers or staff.</p>
 

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { SafeLink } from '../components/global/safeLink'
+import { StyledList } from '../components/global/text'
 import withPageMetadata, { WithPageMetadataProps } from '../components/global/withPageMetadata'
 import Page from '../layouts/withSidebar'
 
@@ -10,7 +11,7 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
     description={'How to contact ' + props.pageMetadata.conference.Name + '.'}
   >
     <h1>Contact Us</h1>
-    <ul>
+    <StyledList>
       <li>
         <strong>General enquiries:</strong>{' '}
         <a className="maillink" href={'mailto:' + props.pageMetadata.conference.ContactEmail}>
@@ -37,15 +38,15 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
           ' on ' +
           props.pageMetadata.conference.EmergencyContactPhoneNumber}
       </li>
-    </ul>
+    </StyledList>
     <h2>DDD WA Inc.</h2>
-    <ul>
+    <StyledList>
       <li>
         <strong>ABN:</strong> 61 201 381 758
       </li>
       <li>
         <strong>Postal Address:</strong> PO Box 7550, Perth WA 6000
       </li>
-    </ul>
+    </StyledList>
   </Page>
 ))

--- a/pages/sponsorship.tsx
+++ b/pages/sponsorship.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import React from 'react'
+import { StyledList } from '../components/global/text'
 import withPageMetadata, { WithPageMetadataProps } from '../components/global/withPageMetadata'
 import Page from '../layouts/withSidebar'
 
@@ -22,7 +23,7 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
       sponsors because we attract people that don't normally go to software conferences. This occurs as a natural result
       of our core principles:
     </p>
-    <ul>
+    <StyledList>
       <li>
         Making the ticket price as low as possible ({props.pageMetadata.conference.TicketPrice}); people don't need to
         request PD budget from their employer to attend and it's accessible to most people regardless of financial
@@ -41,7 +42,7 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
         Focussing on creating a safe and inclusive environment where everyone is welcome; encourages a diverse set of
         attendees and attracts repeat visitors and an expanding presence year on year via a growing network
       </li>
-    </ul>
+    </StyledList>
     <p>
       <Link href="/about">
         <a className="btn btn-secondary">Find out more about {props.pageMetadata.conference.Name}</a>

--- a/pages/vote.tsx
+++ b/pages/vote.tsx
@@ -4,6 +4,7 @@ import Router from 'next/router'
 import React from 'react'
 import uuid from 'uuid/v1'
 import { logEvent, logException } from '../components/global/analytics'
+import { StyledList } from '../components/global/text'
 import withPageMetadata, { WithPageMetadataProps } from '../components/global/withPageMetadata'
 import dateTimeProvider from '../components/utils/dateTimeProvider'
 import Voting from '../components/voting'
@@ -237,7 +238,7 @@ class VotePage extends React.Component<VoteProps, VoteState> {
                 sessions submitted! We've implemented the following features to assist you to manage voting across such
                 a large number of sessions:
               </p>
-              <ul>
+              <StyledList>
                 <li>
                   Any actions you take on this page (e.g. vote, shortlist) will be saved to this device/browser -{' '}
                   <strong>you can do the voting over a number of sittings</strong> and don't need to worry about trying
@@ -294,7 +295,7 @@ class VotePage extends React.Component<VoteProps, VoteState> {
                     to maximise the impact of your votes.
                   </li>
                 )}
-              </ul>
+              </StyledList>
             </div>
           </div>
 

--- a/styles/screen.scss
+++ b/styles/screen.scss
@@ -476,9 +476,6 @@ footer {
     li {
       list-style: none outside;
     }
-    li:before {
-      display: none;
-    }
     a {
       color: #fff;
       font-weight: 600;
@@ -496,9 +493,6 @@ footer {
       display: inline-block;
       margin: 0 2px;
       padding: 0;
-    }
-    li:before {
-      display: none;
     }
     a {
       display: block;

--- a/styles/typography.scss
+++ b/styles/typography.scss
@@ -67,26 +67,6 @@ p + ol {
   margin: -10px 0 10px 0;
 }
 
-ul,
-ol {
-  li {
-    margin: 0;
-    padding: 0;
-    list-style: none outside;
-  }
-  li:before {
-    content: '';
-    display: inline-block;
-    vertical-align: middle;
-    width: 7px;
-    height: 7px;
-    background: $primary-color;
-    margin: 0 13px 0 0;
-    position: relative;
-    top: -1px;
-  }
-}
-
 .preserve-whitespace {
   white-space: pre-wrap;
 }


### PR DESCRIPTION
The default styling on list and ordered lists made it a pain to use lists
elsewhere because of having to override the psuedo element. This approach
brings things more inline with the CSS-in-JS approach and returns list to
their default