### PR TITLE
Fixes #240 social link titles

### DIFF
--- a/components/global/socialLinks.tsx
+++ b/components/global/socialLinks.tsx
@@ -14,7 +14,6 @@ const SocialLinks: StatelessComponent<SocialLinksArgs> = ({ socials }) => (
           className="fa fa-twitter"
           rel="noopener nofollow"
           href={`https://twitter.com/${socials.Twitter.Name}`}
-          title="Twitter, will open in a new window"
           aria-label="Twitter, will open in a new window"
           target="_blank"
         />
@@ -26,7 +25,6 @@ const SocialLinks: StatelessComponent<SocialLinksArgs> = ({ socials }) => (
           rel="noopener nofollow"
           className="fa fa-facebook"
           href={`https://facebook.com/${socials.Facebook}`}
-          title="Facebook, will open in a new window"
           aria-label="Facebook, will open in a new window"
           target="_blank"
         />
@@ -38,7 +36,6 @@ const SocialLinks: StatelessComponent<SocialLinksArgs> = ({ socials }) => (
           rel="noopener nofollow"
           className="fa fa-github"
           href={`https://github.com/${socials.GitHub}`}
-          title="GitHub, will open in a new window"
           aria-label="GitHub, will open in a new window"
           target="_blank"
         />
@@ -50,7 +47,6 @@ const SocialLinks: StatelessComponent<SocialLinksArgs> = ({ socials }) => (
           rel="noopener nofollow"
           className="fa fa-instagram"
           href={`https://www.instagram.com/${socials.Instagram}`}
-          title="Instagram, will open in a new window"
           aria-label="Instagram, will open in a new window"
           target="_blank"
         />
@@ -62,7 +58,6 @@ const SocialLinks: StatelessComponent<SocialLinksArgs> = ({ socials }) => (
           rel="noopener nofollow"
           className="fa fa-flickr"
           href={socials.Flickr}
-          title="Flickr, will open in a new window"
           aria-label="Flickr, will open in a new window"
           target="_blank"
         />
@@ -74,7 +69,6 @@ const SocialLinks: StatelessComponent<SocialLinksArgs> = ({ socials }) => (
           rel="noopener nofollow"
           className="fa fa-youtube"
           href={socials.Youtube}
-          title="YouTube, will open in a new window"
           aria-label="YouTube, will open in a new window"
           target="_blank"
         />
@@ -86,7 +80,6 @@ const SocialLinks: StatelessComponent<SocialLinksArgs> = ({ socials }) => (
           rel="noopener nofollow"
           className="fa fa-pencil"
           href={socials.Blog}
-          title="Blog, will open in a new window"
           aria-label="Blog, will open in a new window"
           target="_blank"
         />
@@ -98,7 +91,6 @@ const SocialLinks: StatelessComponent<SocialLinksArgs> = ({ socials }) => (
           rel="noopener nofollow"
           className="fa fa-envelope"
           href={`mailto:${socials.Email}`}
-          title="Email, will open in system default mail app"
           aria-label="Email, will open in system default mail app"
         />
       </li>
@@ -109,7 +101,6 @@ const SocialLinks: StatelessComponent<SocialLinksArgs> = ({ socials }) => (
           rel="noopener nofollow"
           className="fa fa-envelope-o"
           href={socials.MailingList}
-          title="Mailing List, will open in a new window"
           aria-label="Mailing List, will open in a new window"
           target="_blank"
         />


### PR DESCRIPTION
Fixes multiple title attribute issue raised in our accessibility audit.
This should ensure that we don't have the title read multiple times. We
are relying on aria-label instead of the hidden text which looking at
the accessibility toolbar appears to be ok.