### PR TITLE
Removes React Bootstrap Typeahead

### DIFF
--- a/components/global/meta.tsx
+++ b/components/global/meta.tsx
@@ -63,7 +63,6 @@ const Meta: StatelessComponent<MetaArgs> = ({
         integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN"
         crossOrigin="anonymous"
       />
-      <link rel="stylesheet" href="https://unpkg.com/react-bootstrap-typeahead/css/Typeahead.css" />
       <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" />
       <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Montserrat:700" />
       <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Overpass+Mono:700" />

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "react": "^16.8.5",
     "react-beautiful-dnd": "^12.2.0",
     "react-bootstrap": "^0.32.1",
-    "react-bootstrap-typeahead": "^3.1.3",
     "react-dom": "^16.8.4",
     "react-ga": "^2.4.1",
     "uuid": "^3.3.3"
@@ -45,7 +44,6 @@
     "@types/react": "16.8.5",
     "@types/react-beautiful-dnd": "^12.1.1",
     "@types/react-bootstrap": "^0.32.1",
-    "@types/react-bootstrap-typeahead": "^2.3.0",
     "@types/react-ga": "^2.3.0",
     "@types/styled-jsx": "^2.2.1",
     "@types/uuid": "^3.4.5",


### PR DESCRIPTION
React Bootstrap Typeahead isn't used within the codebase. Remove the
dependences and importantly the stylesheet that would be extra weight on
the page.