### PR TITLE
Create lhci.yml

### DIFF
--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -1,0 +1,21 @@
+name: Lighthouse
+
+on: [repository_dispatch]
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Audit URLs using Lighthouse
+        uses: treosh/lighthouse-ci-action@v2
+        with:
+          urls: |
+            https://dddperth.com/
+            https://dddperth.com/about
+            https://dddperth.com/agenda
+      - name: Save results
+        uses: actions/upload-artifact@v1
+        with:
+          name: lighthouse-results
+          path: '.lighthouseci' # This will save the Lighthouse results as .json files


### PR DESCRIPTION
Creates GitHub action to test DDD's most popular pages with Lighthouse-CI. Uses the repository dispatch trigger that will come from Azure Dev Ops.