### PR TITLE
Refactors 2018 agenda to match 2019

### DIFF
--- a/components/Agenda/Agenda.styled.tsx
+++ b/components/Agenda/Agenda.styled.tsx
@@ -5,7 +5,11 @@ import styled from '../utils/styles/theme'
 const rowBackgroundColor = '#f9f9f9'
 const cellBorder = '1px solid #ddd'
 
-export const StyledAgendaRow = styled('section')({
+interface StyledAgendaRowProps {
+  tracks?: number
+}
+
+export const StyledAgendaRow = styled('section')<StyledAgendaRowProps>(({ tracks = 6 }) => ({
   display: 'grid',
   gridTemplateColumns: `repeat(2, 1fr)`,
   backgroundColor: rowBackgroundColor,
@@ -24,23 +28,23 @@ export const StyledAgendaRow = styled('section')({
       borderRight: 0,
     },
 
-    '& > section:nth-last-child(n+3)': {
+    [`& > section:nth-last-child(n+${Math.floor(tracks / 2)})`]: {
       borderBottom: cellBorder,
     },
   },
 
   [breakpointBetween('xs', 'sm')]: {
-    '& > section:nth-child(3n+1)': {
+    [`& > section:nth-child(${Math.floor(tracks / 2)}n+1)`]: {
       borderRight: 0,
     },
 
-    '& > section:nth-last-child(n+4)': {
+    [`& > section:nth-last-child(n+${Math.floor(tracks / 2) + 1})`]: {
       borderBottom: cellBorder,
     },
   },
 
   [breakpoint('xs')]: {
-    gridTemplateColumns: `repeat(3, 1fr)`,
+    gridTemplateColumns: `repeat(${Math.floor(tracks / 2)}, 1fr)`,
   },
 
   [breakpoint('sm')]: {
@@ -49,7 +53,7 @@ export const StyledAgendaRow = styled('section')({
       borderRight: cellBorder,
     },
   },
-})
+}))
 StyledAgendaRow.displayName = 'StyledAgendaRow'
 
 export const StyledAgendaRowList = styled('ul')(({ theme }) => ({

--- a/components/Agenda/AgendaPage.tsx
+++ b/components/Agenda/AgendaPage.tsx
@@ -36,7 +36,7 @@ export const agendaPage = (
 
           <WrappedComponent sessions={sessions} />
 
-          <AllAgendas conference={conference} dates={dates} conferenceInstance="2019" />
+          <AllAgendas conference={conference} dates={dates} conferenceInstance={externalProps.conferenceInstance} />
         </div>
       </Page>
     )

--- a/config/2018.ts
+++ b/config/2018.ts
@@ -104,12 +104,19 @@ const From2018: From2018 = {
       url: 'https://mechanicalrock.io/',
     },
     {
-      id: 'yow-perth',
+      id: 'yow-perth-keynote',
       imageUrl: '/static/images/sponsors/yow-perth.png',
       name: 'YOW! Perth',
       serviceProvided: 'Keynote',
       type: SponsorType.Service,
       url: 'http://west.yowconference.com.au/',
+    },
+    {
+      id: 'bankwest',
+      imageUrl: '/static/images/sponsors/bankwest.png',
+      name: 'Bankwest',
+      type: SponsorType.Standard,
+      url: 'https://www.bankwest.com.au/',
     },
     // Standard
     {

--- a/config/2019.ts
+++ b/config/2019.ts
@@ -11,8 +11,8 @@ interface From2019 {
 
 export const From2019: From2019 = {
   YouTubePlaylistUrl: 'https://www.youtube.com/watch?v=rDzlITb-Ro8&list=PLkLJSte3oodR5ibzOgr7LsGsVXPdP70kE',
-  YouTubeKeynoteEmbedUrl: 'https://www.youtube.com/watch?v=rDzlITb-Ro8',
-  YouTubeLocknoteEmbedUrl: 'https://www.youtube.com/watch?v=Im-PgWfRyF8',
+  YouTubeKeynoteEmbedUrl: 'https://www.youtube.com/embed/rDzlITb-Ro8',
+  YouTubeLocknoteEmbedUrl: 'https://www.youtube.com/embed/Im-PgWfRyF8',
   FlickrAlbumUrl: 'https://www.flickr.com/photos/135003652@N08/albums/72157711972856726',
   HandbookUrl: '/static/docs/handbook2019.pdf',
   Sponsors: [

--- a/pages/agenda/2018.tsx
+++ b/pages/agenda/2018.tsx
@@ -1,281 +1,264 @@
 import React, { Fragment } from 'react'
-import AgendaPage, { AgendaPageParameters, AgendaPageProps } from '../../components/agendaPage'
-import { SafeLink } from '../../components/global/safeLink'
+import { AgendaPageParameters, agendaPage } from '../../components/Agenda/AgendaPage'
 import withPageMetadata from '../../components/global/withPageMetadata'
-import ResponsiveVideo from '../../components/responsiveVideo'
 import Sponsors from '../../components/sponsors'
 import From2018 from '../../config/2018'
-import { SponsorType } from '../../config/types'
+import { SponsorType, Session } from '../../config/types'
+import moment from 'moment'
+import ResponsiveVideo from '../../components/responsiveVideo'
+import { SafeLink } from '../../components/global/safeLink'
+import { Agenda } from '../../components/Agenda/Agenda'
+import { AgendaProvider } from '../../components/Agenda/AgendaContext'
+import {
+  StyledAgendaRowList,
+  StyledAgendaRow,
+  StyledTrackHeader,
+  StyledAddress,
+} from '../../components/Agenda/Agenda.styled'
+import { AgendaTime } from '../../components/Agenda/AgendaTime'
+import { AgendaSession } from '../../components/Agenda/AgendaSession'
+import { StyledAgendaPresenter } from '../../components/Agenda/AgendaSession.styled'
 
-class Agenda2018 extends React.Component<AgendaPageProps> {
-  static getAgendaPageParams(): AgendaPageParameters {
-    return {
-      conferenceInstance: '2018',
-      numTracks: 4,
-      sessionsUrl: '/static/agenda/2018.json',
-      sponsors: [],
-    }
-  }
-
-  render() {
-    const SessionCell = this.props.SessionCell
-    return (
-      <Fragment>
-        <div style={{ overflow: 'auto' }}>
-          <table className="agenda-row table">
-            <thead>
-              <tr>
-                <th style={{ width: '4%' }} />
-                <th style={{ width: '24%' }}>
-                  <strong className="room">RR4</strong>
-                </th>
-                <th style={{ width: '24%' }}>
-                  <strong className="room">M3</strong>
-                </th>
-                <th style={{ width: '24%' }}>
-                  <strong className="room">M2</strong>
-                </th>
-                <th style={{ width: '24%' }}>
-                  <strong className="room">M1</strong>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr className="breadth-row">
-                <td className="time">8:00</td>
-                <td colSpan={4} className="breadth">
-                  Registration
-                  <br />
-                  <em>Perth Convention and Exhibition Centre</em>
-                  <br />
-                  21 Mounts Bay Rd, Perth
-                  <br />
-                  <small className="room">Upstairs foyer (Level 3)</small>
-                </td>
-              </tr>
-
-              <tr className="breadth-row">
-                <td className="time">8:45</td>
-                <td colSpan={4} className="breadth">
-                  Welcome and housekeeping
-                  <br />
-                  <small className="room">VGW Ballroom 2</small>
-                </td>
-              </tr>
-
-              <tr className="breadth-row">
-                <td className="time">9:00</td>
-                <td colSpan={4} className="breadth">
-                  Welcome to country
-                  <br />
-                  <small className="room">VGW Ballroom 2</small>
-                </td>
-              </tr>
-
-              <tr className="breadth-row">
-                <td className="time">9:10</td>
-                <SessionCell
-                  isKeynote={true}
-                  sessionId="c79f149d-4e7b-4202-ba30-13cbb1df1b33"
-                  sponsorName="YOW! Perth"
-                  room="VGW Ballroom 2"
-                />
-              </tr>
-
-              <tr className="breadth-row">
-                <td className="time">9:55</td>
-                <td colSpan={4} className="breadth">
-                  Changeover
-                </td>
-              </tr>
-
-              <tr>
-                <td className="time">10:05</td>
-                <SessionCell sessionId="68927257-08c3-41f7-9810-5d290c373405" />
-                <SessionCell sessionId="318d8f95-54e8-486b-8119-94bb91924f64" />
-                <SessionCell sessionId="ab660bb2-d12a-4627-9c2a-b92900e87bca" />
-                <SessionCell sessionId="77fea600-238f-4523-baf8-f51b5db5d666" />
-              </tr>
-
-              <tr className="breadth-row">
-                <td className="time">10:50</td>
-                <td colSpan={4} className="breadth">
-                  Morning tea
-                  <br />
-                  <small className="room">Upstairs foyer</small>
-                </td>
-              </tr>
-
-              <tr>
-                <td className="time">11:20</td>
-                <SessionCell sessionId="24bc1c06-ec0d-4ba0-8d3e-a995d2118f46" />
-                <SessionCell sessionId="0f383402-2fee-4728-a6bf-fbe74ba2671e" />
-                <SessionCell sessionId="0d35dfb9-c75f-48a4-bd73-18fe07f6a04b" />
-                <SessionCell sessionId="88344a80-a3e8-484a-93b6-e6a4f80af84f" />
-              </tr>
-
-              <tr className="breadth-row">
-                <td className="time">11:40</td>
-                <td colSpan={4} className="breadth">
-                  Changeover
-                </td>
-              </tr>
-
-              <tr>
-                <td className="time">11:50</td>
-                <SessionCell sessionId="6cf90233-65d8-4bdd-868f-9d13683aac78" />
-                <SessionCell sessionId="96326393-7372-46d0-a07c-3006b97517cf" />
-                <SessionCell sessionId="ee60b006-8662-4d8c-8a60-4ee4ad2018f7" />
-                <SessionCell sessionId="a45d6be4-668d-4c01-8522-34c43580baab" />
-              </tr>
-
-              <tr className="breadth-row">
-                <td className="time">12:10</td>
-                <td colSpan={4} className="breadth">
-                  Changeover
-                </td>
-              </tr>
-
-              <tr>
-                <td className="time">12:20</td>
-                <SessionCell sessionId="5588dee1-39a1-47a9-bc04-376ff1578930" />
-                <SessionCell sessionId="dd4a2717-47ed-426f-a97d-5bb4f9c1fef3" />
-                <SessionCell sessionId="a9c48983-c3c9-4ceb-b21b-6b1d116a6882" />
-                <SessionCell sessionId="c0f29a8d-0c21-43d6-aeb1-c34054e6541f" />
-              </tr>
-
-              <tr className="breadth-row">
-                <td className="time">13:05</td>
-                <td colSpan={4} className="breadth">
-                  Lunch
-                  <br />
-                  <small className="room">Upstairs foyer</small>
-                </td>
-              </tr>
-
-              <tr className="breadth-row">
-                <td className="time">13:15</td>
-                <SessionCell
-                  isLunchnote={true}
-                  sessionId="26c62196-0d96-4e52-b4ba-7896ddf2ff04"
-                  sponsorName="Bankwest"
-                  room="VGW Ballroom 2"
-                />
-              </tr>
-
-              <tr className="breadth-row">
-                <td className="time">13:45</td>
-                <td colSpan={4} className="breadth">
-                  Lunch (continued)
-                  <br />
-                  <small className="room">Upstairs foyer</small>
-                </td>
-              </tr>
-
-              <tr>
-                <td className="time">14:05</td>
-                <SessionCell sessionId="3a0236e4-c8fa-4cc9-ab48-fc0371a6b990" />
-                <SessionCell sessionId="2f2a3626-5ec3-4085-baca-941910c09467" />
-                <SessionCell sessionId="9ac2e311-7559-436c-8ee8-6f0aed17a431" />
-                <SessionCell sessionId="9a72d1fa-6563-4de2-bb3c-27d13d7e0d64" />
-              </tr>
-
-              <tr className="breadth-row">
-                <td className="time">14:25</td>
-                <td colSpan={4} className="breadth">
-                  Changeover
-                </td>
-              </tr>
-
-              <tr>
-                <td className="time">14:35</td>
-                <SessionCell sessionId="f7fc010d-8c47-4b86-b1e9-1221b63e0281" />
-                <SessionCell sessionId="2234f8f6-6e13-4998-ba37-baf53ae44d9d" />
-                <SessionCell sessionId="4f463f9b-bf28-446a-9558-c6ac59697cc9" />
-                <SessionCell sessionId="fd830fb5-8e7b-4527-bc79-f7ddf693232f" />
-              </tr>
-
-              <tr className="breadth-row">
-                <td className="time">15:20</td>
-                <td colSpan={4} className="breadth">
-                  Afternoon tea
-                  <br />
-                  <small className="room">Upstairs foyer</small>
-                </td>
-              </tr>
-
-              <tr className="breadth-row">
-                <td className="time">15:50</td>
-                <td colSpan={4} className="breadth">
-                  Prize Draw
-                  <br />
-                  <small className="room">VGW Ballroom 2</small>
-                </td>
-              </tr>
-
-              <tr className="breadth-row">
-                <td className="time">16:20</td>
-                <SessionCell
-                  isLocknote={true}
-                  sessionId="264b7669-8127-41a3-9f6b-87511a879cf1"
-                  sponsorName="YOW! Perth"
-                  room="VGW Ballroom 2"
-                />
-              </tr>
-
-              <tr className="breadth-row">
-                <td className="time">17:05</td>
-                <td colSpan={4} className="breadth">
-                  <strong>Thank yous and wrap up</strong>
-                  <br />
-                  <small className="room">VGW Ballroom 2</small>
-                </td>
-              </tr>
-
-              <tr className="breadth-row">
-                <td className="time">17:10</td>
-                <td colSpan={4} className="breadth">
-                  <strong>Afterparty</strong>
-                  <br />
-                  <small className="room">Upstairs foyer</small>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <h2>Handbook</h2>
-        <p>
-          <a className="btn btn-pdf" href={From2018.HandbookUrl}>
-            Download 2018 handbook (PDF)
-          </a>
-        </p>
-        <h2>Media</h2>
-
-        <div className="text-center">
-          <ResponsiveVideo src={From2018.YouTubeKeynoteEmbedUrl} />
-          <ResponsiveVideo src={From2018.YouTubeLocknoteEmbedUrl} />
-        </div>
-        <br />
-        <div>
-          <ResponsiveVideo src={From2018.YouTubeLunchnoteEmbedUrl} />
-        </div>
-        <p>
-          <SafeLink href={From2018.YouTubePlaylistUrl} target="_blank">
-            YouTube Playlist
-          </SafeLink>{' '}
-          |{' '}
-          <SafeLink href={From2018.FlickrAlbumUrl} target="_blank">
-            Flickr Album
-          </SafeLink>
-        </p>
-        <Sponsors
-          show={true}
-          hideUpsell={true}
-          sponsors={From2018.Sponsors.filter(s => s.type === SponsorType.Gold || s.type === SponsorType.Platinum)}
-        />
-      </Fragment>
-    )
-  }
+const agendaParams: AgendaPageParameters = {
+  conferenceInstance: '2018',
+  numTracks: 4,
+  sessionsUrl: '/static/agenda/2018.json',
 }
 
-export default withPageMetadata(AgendaPage<AgendaPageProps>(Agenda2018, Agenda2018.getAgendaPageParams()))
+const Agenda2018: React.FC<AgendaPageParameters & { sessions: Session[] }> = ({ sessions }) => {
+  const date = moment.parseZone('2018-08-04T08:00+08:00')
+
+  return (
+    <Fragment>
+      <Agenda
+        sessions={sessions}
+        sessionsUrl={agendaParams.sessionsUrl}
+        acceptingFeedback={false}
+        selectedSessionId={undefined}
+        render={(agendaSessions, _, onSelect) => {
+          return (
+            <AgendaProvider
+              onSelect={onSelect}
+              sessions={agendaSessions}
+              sponsors={From2018.Sponsors}
+              rooms={['RR4', 'M3', 'M2', 'M1']}
+            >
+              <StyledAgendaRowList>
+                <li>Time</li>
+                <li>RR4</li>
+                <li>M3</li>
+                <li>M2</li>
+                <li>M1</li>
+              </StyledAgendaRowList>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone()} />
+                <AgendaSession room="Upstairs foyer (Level 3)" alwaysShowRoom fullWidth>
+                  <StyledTrackHeader>Registration</StyledTrackHeader>
+                  <StyledAddress>
+                    Perth Convention and Exhibition Centre
+                    <br />
+                    21 Mounts Bay Rd, Perth
+                  </StyledAddress>
+                </AgendaSession>
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ minutes: 45 })} />
+                <AgendaSession room="VGW Ballroom 2" alwaysShowRoom fullWidth>
+                  <StyledTrackHeader>Welcome and housekeeping</StyledTrackHeader>
+                </AgendaSession>
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set('hour', 9)} />
+                <AgendaSession room="VGW Ballroom 2" alwaysShowRoom fullWidth>
+                  <StyledTrackHeader>Welcome to country</StyledTrackHeader>
+                </AgendaSession>
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 9, minutes: 10 })} />
+                <AgendaSession
+                  sessionId="c79f149d-4e7b-4202-ba30-13cbb1df1b33"
+                  sponsorId="yow-perth-keynote"
+                  room="VGW Ballroom 2"
+                  renderPresenters={presenters => (
+                    <StyledAgendaPresenter isKeynote>Keynote: {presenters}</StyledAgendaPresenter>
+                  )}
+                  fullWidth
+                  isKeynote
+                  alwaysShowRoom
+                />
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 9, minutes: 55 })} />
+                <AgendaSession fullWidth>
+                  <StyledTrackHeader>Changeover</StyledTrackHeader>
+                </AgendaSession>
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 10, minutes: 5 })} />
+                <AgendaSession room={0} sessionId="68927257-08c3-41f7-9810-5d290c373405" />
+                <AgendaSession room={1} sessionId="318d8f95-54e8-486b-8119-94bb91924f64" />
+                <AgendaSession room={2} sessionId="ab660bb2-d12a-4627-9c2a-b92900e87bca" />
+                <AgendaSession room={3} sessionId="77fea600-238f-4523-baf8-f51b5db5d666" />
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 10, minute: 50 })} />
+                <AgendaSession room="Upstairs foyer" alwaysShowRoom fullWidth>
+                  <StyledTrackHeader>Morning tea</StyledTrackHeader>
+                </AgendaSession>
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 11, minutes: 20 })} />
+                <AgendaSession room={0} sessionId="24bc1c06-ec0d-4ba0-8d3e-a995d2118f46" />
+                <AgendaSession room={1} sessionId="0f383402-2fee-4728-a6bf-fbe74ba2671e" />
+                <AgendaSession room={2} sessionId="0d35dfb9-c75f-48a4-bd73-18fe07f6a04b" />
+                <AgendaSession room={3} sessionId="88344a80-a3e8-484a-93b6-e6a4f80af84f" />
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 11, minutes: 40 })} />
+                <AgendaSession fullWidth>
+                  <StyledTrackHeader>Changeover</StyledTrackHeader>
+                </AgendaSession>
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 11, minutes: 50 })} />
+                <AgendaSession room={0} sessionId="6cf90233-65d8-4bdd-868f-9d13683aac78" />
+                <AgendaSession room={1} sessionId="96326393-7372-46d0-a07c-3006b97517cf" />
+                <AgendaSession room={2} sessionId="ee60b006-8662-4d8c-8a60-4ee4ad2018f7" />
+                <AgendaSession room={3} sessionId="a45d6be4-668d-4c01-8522-34c43580baab" />
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 12, minutes: 10 })} />
+                <AgendaSession fullWidth>
+                  <StyledTrackHeader>Changeover</StyledTrackHeader>
+                </AgendaSession>
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 12, minutes: 20 })} />
+                <AgendaSession room={0} sessionId="5588dee1-39a1-47a9-bc04-376ff1578930" />
+                <AgendaSession room={1} sessionId="dd4a2717-47ed-426f-a97d-5bb4f9c1fef3" />
+                <AgendaSession room={2} sessionId="a9c48983-c3c9-4ceb-b21b-6b1d116a6882" />
+                <AgendaSession room={3} sessionId="c0f29a8d-0c21-43d6-aeb1-c34054e6541f" />
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 13, minute: 5 })} />
+                <AgendaSession room="Upstairs foyer" alwaysShowRoom fullWidth>
+                  <StyledTrackHeader>Lunch</StyledTrackHeader>
+                </AgendaSession>
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 13, minutes: 15 })} />
+                <AgendaSession
+                  sessionId="26c62196-0d96-4e52-b4ba-7896ddf2ff04"
+                  sponsorId="bankwest"
+                  room="VGW Ballroom 2"
+                  renderPresenters={presenters => (
+                    <StyledAgendaPresenter isKeynote>Lunchnote: {presenters}</StyledAgendaPresenter>
+                  )}
+                  fullWidth
+                  isKeynote
+                  alwaysShowRoom
+                />
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 13, minute: 45 })} />
+                <AgendaSession room="Upstairs foyer" alwaysShowRoom fullWidth>
+                  <StyledTrackHeader>Lunch (continued)</StyledTrackHeader>
+                </AgendaSession>
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 14, minutes: 5 })} />
+                <AgendaSession room={0} sessionId="3a0236e4-c8fa-4cc9-ab48-fc0371a6b990" />
+                <AgendaSession room={1} sessionId="2f2a3626-5ec3-4085-baca-941910c09467" />
+                <AgendaSession room={2} sessionId="9ac2e311-7559-436c-8ee8-6f0aed17a431" />
+                <AgendaSession room={3} sessionId="9a72d1fa-6563-4de2-bb3c-27d13d7e0d64" />
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 14, minutes: 25 })} />
+                <AgendaSession fullWidth>
+                  <StyledTrackHeader>Changeover</StyledTrackHeader>
+                </AgendaSession>
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 14, minutes: 35 })} />
+                <AgendaSession room={0} sessionId="f7fc010d-8c47-4b86-b1e9-1221b63e0281" />
+                <AgendaSession room={1} sessionId="2234f8f6-6e13-4998-ba37-baf53ae44d9d" />
+                <AgendaSession room={2} sessionId="4f463f9b-bf28-446a-9558-c6ac59697cc9" />
+                <AgendaSession room={3} sessionId="fd830fb5-8e7b-4527-bc79-f7ddf693232f" />
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 15, minutes: 20 })} />
+                <AgendaSession room="Upstairs foyer" fullWidth>
+                  <StyledTrackHeader>Afternoon tea</StyledTrackHeader>
+                </AgendaSession>
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 15, minutes: 50 })} />
+                <AgendaSession room="VGW Ballroom 2" fullWidth>
+                  <StyledTrackHeader>Prize Draw</StyledTrackHeader>
+                </AgendaSession>
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 16, minutes: 20 })} />
+                <AgendaSession
+                  sessionId="264b7669-8127-41a3-9f6b-87511a879cf1"
+                  sponsorId="yow-perth-keynote"
+                  room="VGW Ballroom 2"
+                  renderPresenters={presenters => (
+                    <StyledAgendaPresenter isKeynote>Locknote: {presenters}</StyledAgendaPresenter>
+                  )}
+                  fullWidth
+                  isKeynote
+                  alwaysShowRoom
+                />
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 17, minutes: 5 })} />
+                <AgendaSession room="VGW Ballroom 2" fullWidth>
+                  <StyledTrackHeader>Thank yous and wrap up</StyledTrackHeader>
+                </AgendaSession>
+              </StyledAgendaRow>
+              <StyledAgendaRow tracks={agendaParams.numTracks}>
+                <AgendaTime time={date.clone().set({ hour: 17, minutes: 10 })} />
+                <AgendaSession room="Upstairs foyer" fullWidth>
+                  <StyledTrackHeader>Afterparty</StyledTrackHeader>
+                </AgendaSession>
+              </StyledAgendaRow>
+            </AgendaProvider>
+          )
+        }}
+      />
+      <h2>Handbook</h2>
+      <p>
+        <a className="btn btn-pdf" href={From2018.HandbookUrl}>
+          Download 2018 handbook (PDF)
+        </a>
+      </p>
+      <h2>Media</h2>
+      <div className="text-center">
+        <ResponsiveVideo src={From2018.YouTubeKeynoteEmbedUrl} />
+        <ResponsiveVideo src={From2018.YouTubeLocknoteEmbedUrl} />
+      </div>
+      <br />
+      <div>
+        <ResponsiveVideo src={From2018.YouTubeLunchnoteEmbedUrl} />
+      </div>
+      <p>
+        <SafeLink href={From2018.YouTubePlaylistUrl} target="_blank">
+          YouTube Playlist
+        </SafeLink>{' '}
+        |{' '}
+        <SafeLink href={From2018.FlickrAlbumUrl} target="_blank">
+          Flickr Album
+        </SafeLink>
+      </p>
+      <Sponsors
+        show={true}
+        hideUpsell={true}
+        sponsors={From2018.Sponsors.filter(s => s.type === SponsorType.Gold || s.type === SponsorType.Platinum)}
+      />
+    </Fragment>
+  )
+}
+Agenda2018.displayName = 'Agenda2018'
+
+export default withPageMetadata(agendaPage(Agenda2018, agendaParams))

--- a/pages/agenda/2019.tsx
+++ b/pages/agenda/2019.tsx
@@ -16,6 +16,8 @@ import { StyledAgendaPresenter } from '../../components/Agenda/AgendaSession.sty
 import { Session, SponsorType } from '../../config/types'
 import moment from 'moment'
 import Sponsors from '../../components/sponsors'
+import ResponsiveVideo from '../../components/responsiveVideo'
+import { SafeLink } from '../../components/global/safeLink'
 
 const agendaParams: AgendaPageParameters = {
   conferenceInstance: '2019',
@@ -223,8 +225,22 @@ const Agenda2019: React.FC<AgendaPageParameters & { sessions: Session[] }> = ({ 
       <h2>Handbook</h2>
       <p>
         <a className="btn btn-pdf" href={From2019.HandbookUrl}>
-          Download handbook (PDF)
+          Download 2019 handbook (PDF)
         </a>
+      </p>
+      <h2>Media</h2>
+      <div className="text-center">
+        <ResponsiveVideo src={From2019.YouTubeKeynoteEmbedUrl} />
+        <ResponsiveVideo src={From2019.YouTubeLocknoteEmbedUrl} />
+      </div>
+      <p>
+        <SafeLink href={From2019.YouTubePlaylistUrl} target="_blank">
+          YouTube Playlist
+        </SafeLink>{' '}
+        |{' '}
+        <SafeLink href={From2019.FlickrAlbumUrl} target="_blank">
+          Flickr Album
+        </SafeLink>
       </p>
       <Sponsors
         show={true}


### PR DESCRIPTION
Moves 2018 agenda into newer components used by 2019. Updates styling
to support differing track lengths. Adds media section to 2019 archive.
Once all agendas are converted we will have:
* Removed the last bootstrap component (2019 goal)
* Standardise agenda layouts
* Remove duplicate agenda rendering