### PR TITLE
Basic single and two column layout

### DIFF
--- a/components/Agenda/AgendaPage.tsx
+++ b/components/Agenda/AgendaPage.tsx
@@ -30,7 +30,7 @@ export const agendaPage = (
       <Main
         title={`${externalProps.conferenceInstance} Agenda`}
         description={`The agenda for ${conference.Name} ${externalProps.conferenceInstance}.`}
-        pageMetadata={pageMetadata}
+        metadata={pageMetadata}
       >
         <div className="container">
           <h1>{externalProps.conferenceInstance} Agenda</h1>

--- a/components/eventDetailsSummary.tsx
+++ b/components/eventDetailsSummary.tsx
@@ -1,43 +1,42 @@
-import React, { StatelessComponent } from 'react'
+import React from 'react'
 import { Action, Conference, Dates, TicketPurchasingOptions } from '../config/types'
 import ActionButton from './actionButton'
 import { StyledList } from './global/text'
+import { useRouter } from 'next/router'
 
 export interface EventDetailsSummaryProps {
   conference: Conference
   primaryAction: Action
-  pagePath: string
   dates: Dates
 }
 
-const EventDetailsSummary: StatelessComponent<EventDetailsSummaryProps> = ({
-  conference,
-  primaryAction,
-  pagePath,
-  dates,
-}) => (
-  <div className="event-details">
-    <h2>
-      <span>{!dates.IsComplete ? 'Next event' : 'Previous event'}</span> <time>{dates.Display}</time>
-    </h2>
-    <StyledList>
-      {conference.TicketPurchasingOptions === TicketPurchasingOptions.SoldOut && (
-        <li>
-          <strong>SOLD OUT</strong>
-        </li>
-      )}
-      {conference.TicketPurchasingOptions === TicketPurchasingOptions.WaitListOpen && (
-        <li>
-          <strong>WAITLIST OPEN</strong>
-        </li>
-      )}
-      {conference.SellingPoints.map((point, i) => (
-        <li key={i}>{point}</li>
-      ))}
-      <li>Only {conference.TicketPrice}</li>
-    </StyledList>
-    {pagePath !== primaryAction.Url && <ActionButton action={primaryAction} />}
-  </div>
-)
+export const EventDetailsSummary: React.FC<EventDetailsSummaryProps> = ({ conference, primaryAction, dates }) => {
+  const { pathname } = useRouter()
+
+  return (
+    <div className="event-details">
+      <h2>
+        <span>{!dates.IsComplete ? 'Next event' : 'Previous event'}</span> <time>{dates.Display}</time>
+      </h2>
+      <StyledList>
+        {conference.TicketPurchasingOptions === TicketPurchasingOptions.SoldOut && (
+          <li>
+            <strong>SOLD OUT</strong>
+          </li>
+        )}
+        {conference.TicketPurchasingOptions === TicketPurchasingOptions.WaitListOpen && (
+          <li>
+            <strong>WAITLIST OPEN</strong>
+          </li>
+        )}
+        {conference.SellingPoints.map((point, i) => (
+          <li key={i}>{point}</li>
+        ))}
+        <li>Only {conference.TicketPrice}</li>
+      </StyledList>
+      {pathname !== primaryAction.Url && <ActionButton action={primaryAction} />}
+    </div>
+  )
+}
 
 export default EventDetailsSummary

--- a/components/global/meta.tsx
+++ b/components/global/meta.tsx
@@ -1,5 +1,6 @@
 import Head from 'next/head'
 import React from 'react'
+import * as analytics from '../../components/global/analytics'
 import { Conference, Dates } from '../../config/types'
 
 interface MetaArgs {
@@ -10,6 +11,13 @@ interface MetaArgs {
   pageImage?: string
   conference: Conference
   dates: Dates
+  googleAnalyticsId: string
+}
+
+declare global {
+  interface Window {
+    GA_INITIALIZED: boolean
+  }
 }
 
 const getTitle = (title: string, conference: Conference, dates: Dates) =>
@@ -25,38 +33,48 @@ export const Meta: React.FC<MetaArgs> = ({
   pageImage,
   conference,
   dates,
-}) => (
-  <Head>
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta charSet="utf-8" />
-    <meta httpEquiv="Content-Type" content="text/html; charset=UTF-8" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-    <link rel="shortcut icon" type="image/x-icon" href="/static/favicon.ico" />
-    <meta name="apple-mobile-web-app-title" content={conference.Name} />
-    <title>{getTitle(pageTitle, conference, dates)}</title>
-    <meta property="og:title" content={getTitle(pageTitle, conference, dates)} />
-    <meta name="twitter:title" content={getTitle(pageTitle, conference, dates).substring(0, 70)} />
-    <meta name="description" content={pageDescription || conference.SiteDescription} />
-    <meta property="og:description" content={pageDescription || conference.SiteDescription} />
-    <meta name="twitter:description" content={(pageDescription || conference.SiteDescription).substring(0, 200)} />
-    <meta name="author" content={conference.Organiser.Name} />
-    <meta property="og:image" content={pageImage || '/static/images/logo-2019.png'} />
-    <meta property="twitter:image" content={pageImage || '/static/images/logo-2019.png'} />
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:site" content={conference.Name} />
-    <meta name="twitter:creator" content={conference.Organiser.Name} />
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" content={conference.Name} />
-    <link rel="canonical" href={pageUrl} />
-    <meta property="og:url" content={pageUrl} />
+  googleAnalyticsId,
+}) => {
+  React.useEffect(() => {
+    if (!window.GA_INITIALIZED) {
+      analytics.init(googleAnalyticsId)
+      window.GA_INITIALIZED = true
+    }
+    analytics.logPageView()
+  }, [googleAnalyticsId])
 
-    <link href="https://fonts.googleapis.com/css?family=Hind:400,500&display=swap" rel="stylesheet" />
+  return (
+    <Head>
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <meta charSet="utf-8" />
+      <meta httpEquiv="Content-Type" content="text/html; charset=UTF-8" />
+      <meta name="apple-mobile-web-app-capable" content="yes" />
+      <link rel="shortcut icon" type="image/x-icon" href="/static/favicon.ico" />
+      <meta name="apple-mobile-web-app-title" content={conference.Name} />
+      <title>{getTitle(pageTitle, conference, dates)}</title>
+      <meta property="og:title" content={getTitle(pageTitle, conference, dates)} />
+      <meta name="twitter:title" content={getTitle(pageTitle, conference, dates).substring(0, 70)} />
+      <meta name="description" content={pageDescription || conference.SiteDescription} />
+      <meta property="og:description" content={pageDescription || conference.SiteDescription} />
+      <meta name="twitter:description" content={(pageDescription || conference.SiteDescription).substring(0, 200)} />
+      <meta name="author" content={conference.Organiser.Name} />
+      <meta property="og:image" content={pageImage || '/static/images/logo-2019.png'} />
+      <meta property="twitter:image" content={pageImage || '/static/images/logo-2019.png'} />
+      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:site" content={conference.Name} />
+      <meta name="twitter:creator" content={conference.Organiser.Name} />
+      <meta property="og:type" content="website" />
+      <meta property="og:site_name" content={conference.Name} />
+      <link rel="canonical" href={pageUrl} />
+      <meta property="og:url" content={pageUrl} />
 
-    {instrumentationKey && (
-      <script
-        type="text/javascript"
-        dangerouslySetInnerHTML={{
-          __html: `
+      <link href="https://fonts.googleapis.com/css?family=Hind:400,500&display=swap" rel="stylesheet" />
+
+      {instrumentationKey && (
+        <script
+          type="text/javascript"
+          dangerouslySetInnerHTML={{
+            __html: `
         var appInsights=window.appInsights||function(a){
         function b(a){c[a]=function(){var b=arguments;c.queue.push(function(){c[a].apply(c,b)})}}var c={config:a},d=document,e=window;setTimeout(function(){var b=d.createElement("script");b.src=a.url||"https://az416426.vo.msecnd.net/scripts/a/ai.0.js",d.getElementsByTagName("script")[0].parentNode.appendChild(b)});try{c.cookie=d.cookie}catch(a){}c.queue=[];for(var f=["Event","Exception","Metric","PageView","Trace","Dependency"];f.length;)b("track"+f.pop());if(b("setAuthenticatedUserContext"),b("clearAuthenticatedUserContext"),b("startTrackEvent"),b("stopTrackEvent"),b("startTrackPage"),b("stopTrackPage"),b("flush"),!a.disableExceptionTracking){f="onerror",b("_"+f);var g=e[f];e[f]=function(a,b,d,e,h){var i=g&&g(a,b,d,e,h);return!0!==i&&c["_"+f](a,b,d,e,h),i}}return c
         }({
@@ -64,8 +82,9 @@ export const Meta: React.FC<MetaArgs> = ({
         });
         window.appInsights=appInsights;
       `,
-        }}
-      />
-    )}
-  </Head>
-)
+          }}
+        />
+      )}
+    </Head>
+  )
+}

--- a/layouts/Layouts.styled.tsx
+++ b/layouts/Layouts.styled.tsx
@@ -1,0 +1,35 @@
+import styled from '../components/utils/styles/theme'
+import { calcRem } from '../components/utils/styles/calcRem'
+import { breakpoint } from '../components/utils/styles/breakpoints'
+
+export const StyledMain = styled('main')(({ theme }) => ({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(1rem, 1fr) minmax(0, 120ch) minmax(1rem, 1fr)',
+  gridGap: calcRem(theme.metrics.md),
+
+  '& > *': {
+    gridColumn: 2,
+  },
+}))
+
+export const StyledSidebarContainer = styled('div')(({ theme }) => ({
+  display: 'table',
+  tableLayout: 'fixed',
+
+  ['@supports(display: grid)']: {
+    display: 'grid',
+    gridGap: calcRem(theme.metrics.md),
+
+    [breakpoint('md')]: {
+      gridTemplateColumns: 'minmax(1rem, 1fr) minmax(0, 90ch) minmax(0, 30ch) minmax(1rem, 1fr)',
+
+      main: {
+        gridColumn: 2,
+      },
+
+      aside: {
+        gridColumn: 3,
+      },
+    },
+  },
+}))

--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -7,6 +7,6 @@ interface MainProps extends TemplateProps {}
 
 export const Main: React.FC<MainProps> = ({ title, description, image, metadata, children }) => (
   <Template title={title} description={description} image={image} metadata={metadata}>
-    <StyledMain>{children}</StyledMain>
+    <StyledMain id="content">{children}</StyledMain>
   </Template>
 )

--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -1,64 +1,12 @@
-import React, { Fragment } from 'react'
-import * as analytics from '../components/global/analytics'
-import { Footer } from '../components/global/Footer/footer'
-import { Meta } from '../components/global/meta'
-import { PageMetadata } from '../components/global/withPageMetadata'
-import { TestingControl } from '../components/TestingControl/TestingControl'
-import Menu from '../config/menu'
-import { SkipToContent } from '../components/SkipToContent/SkipToContent'
-import { Header } from '../components/global/Header/Header'
-import { Nav } from '../components/global/Nav/Nav'
-import { NavigationProvider } from '../components/global/Nav/Nav.context'
+import React from 'react'
+import { Template, TemplateProps } from './template'
+import { StyledMain } from './Layouts.styled'
 
-export interface MainProps {
-  title: string
-  description?: string
-  image?: string
-  pageMetadata: PageMetadata
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface MainProps extends TemplateProps {}
 
-declare global {
-  interface Window {
-    GA_INITIALIZED: boolean
-  }
-}
-
-export const Main: React.FC<MainProps> = props => {
-  const { pageMetadata: metadata } = props
-
-  React.useEffect(() => {
-    if (!window.GA_INITIALIZED) {
-      analytics.init(metadata.conference.GoogleAnalyticsId)
-      window.GA_INITIALIZED = true
-    }
-    analytics.logPageView()
-  }, [metadata])
-
-  return (
-    <Fragment>
-      <Meta
-        pageUrl={metadata.pageUrl}
-        pageTitle={props.title}
-        instrumentationKey={metadata.appConfig.instrumentationKey}
-        pageDescription={props.description}
-        pageImage={props.image}
-        conference={metadata.conference}
-        dates={metadata.dates}
-      />
-      <SkipToContent />
-      <NavigationProvider>
-        <Header metadata={metadata} />
-        <Nav menu={Menu(metadata.conference, metadata.dates).Top} />
-      </NavigationProvider>
-      <main id="content">{props.children}</main>
-      <Footer
-        menu={Menu(metadata.conference, metadata.dates).Footer}
-        socials={metadata.conference.Socials}
-        conference={metadata.conference}
-      />
-      {metadata.appConfig.testingMode && (
-        <TestingControl currentDate={metadata.currentDate} conference={metadata.conference} />
-      )}
-    </Fragment>
-  )
-}
+export const Main: React.FC<MainProps> = ({ title, description, image, metadata, children }) => (
+  <Template title={title} description={description} image={image} metadata={metadata}>
+    <StyledMain>{children}</StyledMain>
+  </Template>
+)

--- a/layouts/template.tsx
+++ b/layouts/template.tsx
@@ -1,0 +1,46 @@
+import React, { Fragment } from 'react'
+import { Footer } from '../components/global/Footer/footer'
+import { Meta } from '../components/global/meta'
+import { PageMetadata } from '../components/global/withPageMetadata'
+import { SkipToContent } from '../components/SkipToContent/SkipToContent'
+import { NavigationProvider } from '../components/global/Nav/Nav.context'
+import { TestingControl } from '../components/TestingControl/TestingControl'
+import { Header } from '../components/global/Header/Header'
+import { Nav } from '../components/global/Nav/Nav'
+import Menu from '../config/menu'
+
+export interface TemplateProps {
+  metadata: PageMetadata
+  title: string
+  description?: string
+  image?: string
+}
+
+export const Template: React.FC<TemplateProps> = ({ metadata, children, title, description, image }) => (
+  <Fragment>
+    <Meta
+      pageUrl={metadata.pageUrl}
+      pageTitle={title}
+      instrumentationKey={metadata.appConfig.instrumentationKey}
+      pageDescription={description}
+      pageImage={image}
+      conference={metadata.conference}
+      dates={metadata.dates}
+      googleAnalyticsId={metadata.conference.GoogleAnalyticsId}
+    />
+    <SkipToContent />
+    <NavigationProvider>
+      <Header metadata={metadata} />
+      <Nav menu={Menu(metadata.conference, metadata.dates).Top} />
+    </NavigationProvider>
+    {children}
+    <Footer
+      menu={Menu(metadata.conference, metadata.dates).Footer}
+      socials={metadata.conference.Socials}
+      conference={metadata.conference}
+    />
+    {metadata.appConfig.testingMode && (
+      <TestingControl currentDate={metadata.currentDate} conference={metadata.conference} />
+    )}
+  </Fragment>
+)

--- a/layouts/withSidebar.tsx
+++ b/layouts/withSidebar.tsx
@@ -1,42 +1,30 @@
-import { StatelessComponent } from 'react'
+import React from 'react'
 import EventDetailsSummary from '../components/eventDetailsSummary'
 import { ImportantDatesList } from '../components/ImportantDatesList/importantDatesList'
 import getConferenceActions from '../config/actions'
-import { Main, MainProps } from './main'
+import { TemplateProps, Template } from './template'
+import { StyledSidebarContainer } from './Layouts.styled'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface WithSidebarProps extends MainProps {}
+interface PageWithSidebarProps extends TemplateProps {}
 
-const WithSidebar: StatelessComponent<WithSidebarProps> = ({ children, pageMetadata, ...props }, context) => (
-  <Main pageMetadata={pageMetadata} {...props}>
-    <section className="right-sidebar">
-      <div className="container">
-        <div className="row">
-          <div className="col-xs-12 col-sm-7 col-md-7 col-lg-8 left-col">{children}</div>
-          <div className="col-xs-12 col-sm-5 col-md-5 col-lg-4 right-col">
-            <div className="inner">
-              <EventDetailsSummary
-                conference={pageMetadata.conference}
-                dates={pageMetadata.dates}
-                primaryAction={
-                  getConferenceActions(pageMetadata.conference, pageMetadata.dates).filter(
-                    a => a.Url !== pageMetadata.pagePath,
-                  )[0]
-                }
-                pagePath={context.pagePath}
-              />
-              <h2>Important Dates</h2>
-              <ImportantDatesList
-                layout="inline"
-                conference={pageMetadata.conference}
-                currentDate={pageMetadata.currentDate}
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-  </Main>
-)
-
-export default WithSidebar
+export const PageWithSidebar: React.FC<PageWithSidebarProps> = ({ children, metadata, title, description, image }) => {
+  return (
+    <Template title={title} description={description} image={image} metadata={metadata}>
+      <StyledSidebarContainer>
+        <main>{children}</main>
+        <aside>
+          <EventDetailsSummary
+            conference={metadata.conference}
+            dates={metadata.dates}
+            primaryAction={
+              getConferenceActions(metadata.conference, metadata.dates).filter(a => a.Url !== metadata.pagePath)[0]
+            }
+          />
+          <h2>Important Dates</h2>
+          <ImportantDatesList layout="inline" conference={metadata.conference} currentDate={metadata.currentDate} />
+        </aside>
+      </StyledSidebarContainer>
+    </Template>
+  )
+}

--- a/layouts/withSidebar.tsx
+++ b/layouts/withSidebar.tsx
@@ -12,7 +12,7 @@ export const PageWithSidebar: React.FC<PageWithSidebarProps> = ({ children, meta
   return (
     <Template title={title} description={description} image={image} metadata={metadata}>
       <StyledSidebarContainer>
-        <main>{children}</main>
+        <main id="content">{children}</main>
         <aside>
           <EventDetailsSummary
             conference={metadata.conference}

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -3,10 +3,14 @@ import React from 'react'
 import { SafeLink } from '../components/global/safeLink'
 import { StyledList } from '../components/global/text'
 import withPageMetadata, { WithPageMetadataProps } from '../components/global/withPageMetadata'
-import Page from '../layouts/withSidebar'
+import { PageWithSidebar } from '../layouts/withSidebar'
 
 export default withPageMetadata((props: WithPageMetadataProps) => (
-  <Page pageMetadata={props.pageMetadata} title="About" description="The goal and history of DDD Perth and DDD WA Inc.">
+  <PageWithSidebar
+    metadata={props.pageMetadata}
+    title="About"
+    description="The goal and history of DDD Perth and DDD WA Inc."
+  >
     <h1>About DDD Perth</h1>
     <p>
       {props.pageMetadata.conference.TagLine}. {props.pageMetadata.conference.Goal} We do this by:
@@ -129,5 +133,5 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
         <img src="/static/images/logo-dddbrisbane-2019.jpg" alt="DDD Brisbane logo" style={{ height: '125px' }} />
       </SafeLink>
     </p>
-  </Page>
+  </PageWithSidebar>
 ))

--- a/pages/agenda.tsx
+++ b/pages/agenda.tsx
@@ -47,7 +47,7 @@ class AgendaPage extends React.Component<AgendaPageProps> {
     const dates = this.props.pageMetadata.dates
 
     return (
-      <Main pageMetadata={this.props.pageMetadata} title="Agenda" description={conference.Name + ' agenda.'}>
+      <Main metadata={this.props.pageMetadata} title="Agenda" description={conference.Name + ' agenda.'}>
         <div className="container">
           <h1>{dates.IsComplete && conference.Instance} Agenda</h1>
 

--- a/pages/cfp.tsx
+++ b/pages/cfp.tsx
@@ -7,7 +7,7 @@ import withPageMetadata, { WithPageMetadataProps } from '../components/global/wi
 import dateTimeProvider from '../components/utils/dateTimeProvider'
 import Conference from '../config/conference'
 import getConferenceDates from '../config/dates'
-import Page from '../layouts/withSidebar'
+import { PageWithSidebar } from '../layouts/withSidebar'
 
 class CFPPage extends React.Component<WithPageMetadataProps> {
   static getInitialProps({ res }) {
@@ -29,8 +29,8 @@ class CFPPage extends React.Component<WithPageMetadataProps> {
     const dates = this.props.pageMetadata.dates
     const conference = this.props.pageMetadata.conference
     return (
-      <Page
-        pageMetadata={this.props.pageMetadata}
+      <PageWithSidebar
+        metadata={this.props.pageMetadata}
         title="Call For Presentations (CFP)"
         description={conference.Name + ' Call For Presentations (CFP) page.'}
       >
@@ -143,7 +143,7 @@ class CFPPage extends React.Component<WithPageMetadataProps> {
             Edit your session(s) via Sessionize
           </SafeLink>
         </p>
-      </Page>
+      </PageWithSidebar>
     )
   }
 }

--- a/pages/code-of-conduct.tsx
+++ b/pages/code-of-conduct.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { StyledList } from '../components/global/text'
 import withPageMetadata, { WithPageMetadataProps } from '../components/global/withPageMetadata'
-import Page from '../layouts/withSidebar'
+import { PageWithSidebar } from '../layouts/withSidebar'
 
 export default withPageMetadata((props: WithPageMetadataProps) => (
-  <Page
-    pageMetadata={props.pageMetadata}
+  <PageWithSidebar
+    metadata={props.pageMetadata}
     title="Code of Conduct"
     description={'Code of Conduct for ' + props.pageMetadata.conference.Name + '.'}
   >
@@ -223,5 +223,5 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
     </p>
 
     <p>Last update: 30 Apr 2018</p>
-  </Page>
+  </PageWithSidebar>
 ))

--- a/pages/conference-feedback.tsx
+++ b/pages/conference-feedback.tsx
@@ -79,7 +79,7 @@ const ConferenceFeedback: NextPage<WithPageMetadataProps> = ({ pageMetadata }) =
 
   return (
     <Main
-      pageMetadata={pageMetadata}
+      metadata={pageMetadata}
       title="Conference Feedback"
       description={`${conference.Name} ${conference.Instance} feedback`}
     >

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -2,13 +2,13 @@ import React from 'react'
 import { SafeLink } from '../components/global/safeLink'
 import { StyledList } from '../components/global/text'
 import withPageMetadata, { WithPageMetadataProps } from '../components/global/withPageMetadata'
-import Page from '../layouts/withSidebar'
+import { PageWithSidebar } from '../layouts/withSidebar'
 
 export default withPageMetadata((props: WithPageMetadataProps) => (
-  <Page
-    pageMetadata={props.pageMetadata}
+  <PageWithSidebar
+    metadata={props.pageMetadata}
     title="Contact Us"
-    description={'How to contact ' + props.pageMetadata.conference.Name + '.'}
+    description={`How to contact ${props.pageMetadata.conference.Name}.`}
   >
     <h1>Contact Us</h1>
     <StyledList>
@@ -48,5 +48,5 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
         <strong>Postal Address:</strong> PO Box 7550, Perth WA 6000
       </li>
     </StyledList>
-  </Page>
+  </PageWithSidebar>
 ))

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -2,17 +2,17 @@ import React from 'react'
 import { FaqList } from '../components/FAQList/FaqList'
 import withPageMetadata, { WithPageMetadataProps } from '../components/global/withPageMetadata'
 import getFaqs from '../config/faqs'
-import Page from '../layouts/withSidebar'
+import { PageWithSidebar } from '../layouts/withSidebar'
 
 const FaqPage: React.StatelessComponent<WithPageMetadataProps> = props => (
-  <Page
-    pageMetadata={props.pageMetadata}
+  <PageWithSidebar
+    metadata={props.pageMetadata}
     title="FAQs"
     description={`Frequently asked questions for the ${props.pageMetadata.conference.Name} conference.`}
   >
     <h1>FAQs</h1>
     <FaqList faqs={getFaqs(props.pageMetadata.dates)} />
-  </Page>
+  </PageWithSidebar>
 )
 
 export default withPageMetadata(FaqPage)

--- a/pages/feedback.tsx
+++ b/pages/feedback.tsx
@@ -96,7 +96,7 @@ const Feedback: NextPage<FeedbackMetadataProps> = ({ pageMetadata, ssrSessions }
 
   return (
     <Main
-      pageMetadata={pageMetadata}
+      metadata={pageMetadata}
       title="Feedback"
       description={`${conference.Name} ${conference.Instance} session feedback.`}
     >

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -27,7 +27,7 @@ class Index extends React.Component<IndexProps & WithPageMetadataProps> {
     const dates = this.props.pageMetadata.dates
     const actions = getConferenceActions(conference, dates)
     return (
-      <Main pageMetadata={this.props.pageMetadata} title="Home">
+      <Main metadata={this.props.pageMetadata} title="Home">
         <EventDetails conference={conference} dates={dates} primaryAction={actions[0]} />
         <ImportantDates conference={conference} actions={actions} currentDate={this.props.pageMetadata.currentDate} />
         <Keynotes conference={conference} />

--- a/pages/sponsorship.tsx
+++ b/pages/sponsorship.tsx
@@ -2,10 +2,14 @@ import Link from 'next/link'
 import React from 'react'
 import { StyledList } from '../components/global/text'
 import withPageMetadata, { WithPageMetadataProps } from '../components/global/withPageMetadata'
-import Page from '../layouts/withSidebar'
+import { PageWithSidebar } from '../layouts/withSidebar'
 
 export default withPageMetadata((props: WithPageMetadataProps) => (
-  <Page pageMetadata={props.pageMetadata} title="Sponsorship" description="Sponsorship opportunities for DDD Perth.">
+  <PageWithSidebar
+    metadata={props.pageMetadata}
+    title="Sponsorship"
+    description="Sponsorship opportunities for DDD Perth."
+  >
     <h1>Sponsorship</h1>
 
     <p>
@@ -78,5 +82,5 @@ export default withPageMetadata((props: WithPageMetadataProps) => (
         Explore sponsorship opportunities
       </a>
     </p>
-  </Page>
+  </PageWithSidebar>
 ))

--- a/pages/tickets.tsx
+++ b/pages/tickets.tsx
@@ -66,11 +66,7 @@ class TicketPage extends React.Component<WithPageMetadataProps> {
     }
 
     return (
-      <Main
-        pageMetadata={this.props.pageMetadata}
-        title="Tickets"
-        description={`Purchase tickets for ${conference.Name}`}
-      >
+      <Main metadata={this.props.pageMetadata} title="Tickets" description={`Purchase tickets for ${conference.Name}`}>
         <StyledContainer>
           <h1>Tickets</h1>
           {this.props.pageMetadata.conference.TicketPurchasingOptions === TicketPurchasingOptions.WaitListOpen && (

--- a/pages/venue.tsx
+++ b/pages/venue.tsx
@@ -23,7 +23,7 @@ class VenuePage extends React.Component<WithPageMetadataProps> {
       return <Error statusCode={404} />
     }
     return (
-      <Main pageMetadata={this.props.pageMetadata} title="Venue" description={`About the ${conference.Name} venue.`}>
+      <Main metadata={this.props.pageMetadata} title="Venue" description={`About the ${conference.Name} venue.`}>
         <div className="container">
           <h1>Venue</h1>
           <p>

--- a/pages/vote.tsx
+++ b/pages/vote.tsx
@@ -182,7 +182,7 @@ class VotePage extends React.Component<VoteProps, VoteState> {
 
     return (
       <Main
-        pageMetadata={this.props.pageMetadata}
+        metadata={this.props.pageMetadata}
         title="Vote"
         description={`${this.props.pageMetadata.conference.Name} voting page.`}
       >


### PR DESCRIPTION
Sets up the basic grid layout for the single and two column layout. It
isn't final but gives the site a shape. To improve the semantics I
created Template which wraps layouts so they can focus on their layout
and not other concerns.

* Moved the GA init into Meta
* Refactored prop name
* Refactored EventDetailsSummary props