### PR TITLE
Refactors button components

### DIFF
--- a/components/global/Button/Button.styled.ts
+++ b/components/global/Button/Button.styled.ts
@@ -1,121 +1,12 @@
-import { breakpoint } from '../../utils/styles/breakpoints'
 import { calcRem } from '../../utils/styles/calcRem'
 import styled, { Theme } from '../../utils/styles/theme'
 import { ButtonKinds, Size } from './Button'
-
-function buttonState(color: string, dark: string, focus: string) {
-  return {
-    // conflicting with prettier
-    backgroundColor: color,
-    '&:hover': {
-      backgroundColor: dark,
-    },
-    '&:focus': {
-      outline: 0,
-      boxShadow: `0 0 0 3px ${focus}`,
-    },
-  }
-}
-
-function buttonKindStyles(kind: ButtonKinds, theme: Theme) {
-  switch (kind) {
-    case 'inverse':
-      return buttonState(theme.colors.inverse, theme.colors.inverseDark, theme.colors.linkFocusBg)
-    case 'primary':
-      return buttonState(theme.colors.primary, theme.colors.primaryDark, theme.colors.linkFocusBg)
-    case 'tertiary':
-      return buttonState(theme.colors.tertiary, theme.colors.tertiaryDark, theme.colors.linkFocusBg)
-    case 'secondary':
-    default:
-      return buttonState(theme.colors.secondary, theme.colors.secondaryDark, theme.colors.linkFocusBg)
-  }
-}
-
-export interface StyledButtonProps {
-  kind: ButtonKinds
-  size?: Size
-}
+import { CSSObject } from '@emotion/core'
+import { conditionalStyles } from '../../utils/styles/conditionalStyles'
 
 function shouldStyledButtonForwardProps(prop: string) {
-  return prop !== 'kind' && prop !== 'size'
+  return !['size', 'kind'].includes(prop)
 }
-
-export const StyledButton = styled('button', {
-  shouldForwardProp: shouldStyledButtonForwardProps,
-})<StyledButtonProps>(({ theme, kind, size }) => ({
-  ...buttonKindStyles(kind, theme),
-  cursor: 'pointer',
-  display: 'block',
-  margin: 0,
-  padding: size === 'small' ? calcRem(5, 10) : calcRem(6, 12),
-  color: '#fff',
-  border: 'none',
-  fontSize: calcRem(14),
-  fontWeight: theme.weights.bold,
-  lineHeight: size === 'small' ? 1.1 : 1.4,
-  textAlign: 'center',
-  textShadow: '0 1px 3px rgba(0, 0, 0, 0.25)',
-  verticalAlign: 'middle',
-  userSelect: 'none',
-
-  '&[disabled]': {
-    opacity: 0.65,
-    cursor: 'not-allowed',
-  },
-
-  '&:after': {
-    position: 'relative',
-    display: 'inline-block',
-    top: -1,
-    maxWidth: calcRem(20),
-    margin: `0 0 0 ${calcRem(10)}`,
-    content: "'\f0da'",
-    fontFamily: 'FontAwesome',
-    color: '#000',
-    fontSize: calcRem(16),
-    opacity: 0.3,
-    verticalAlign: 'middle',
-  },
-
-  [breakpoint('xs')]: {
-    padding: size === 'small' ? calcRem(5, 10) : calcRem(6, 15, 5),
-  },
-
-  [breakpoint('sm')]: {
-    padding: size === 'small' ? calcRem(5, 10) : calcRem(7, 16, 6),
-    fontSize: size === 'small' ? calcRem(13) : calcRem(15),
-
-    '&:after': {
-      margin: `0 0 0 ${calcRem(17)}`,
-      fontSize: calcRem(19),
-    },
-  },
-
-  [breakpoint('md')]: {
-    padding: size === 'small' ? calcRem(7, 10, 5) : calcRem(8, 20, 7),
-    fontSize: size === 'small' ? calcRem(14) : calcRem(16),
-  },
-
-  [breakpoint('lg')]: {
-    padding: size === 'small' ? calcRem(7, 10, 5) : calcRem(10, 23, 8),
-    fontSize: size === 'small' ? calcRem(15) : calcRem(17),
-
-    '&:after': {
-      margin: `0 0 0 ${calcRem(20)}`,
-      fontSize: calcRem(20),
-    },
-  },
-
-  [breakpoint('xl')]: {
-    padding: size === 'small' ? calcRem(7, 10, 5) : calcRem(12, 25, 10),
-    fontSize: size === 'small' ? calcRem(16) : calcRem(18),
-
-    '&:after': {
-      margin: `0 0 0 ${calcRem(20)}`,
-      fontSize: calcRem(20),
-    },
-  },
-}))
 
 export const StyledLinkButton = styled('button', {
   shouldForwardProp: shouldStyledButtonForwardProps,
@@ -126,12 +17,71 @@ export const StyledLinkButton = styled('button', {
   textDecoration: 'underline',
   background: 'transparent',
   border: 'none',
-  color: theme.colors.primary,
+  color: theme.colors.dddpink,
   cursor: 'pointer',
-  '&:hover': {
-    color: theme.colors.linkHoverFg,
-  },
-  '&:focus': {
-    color: theme.colors.linkFocusBg,
+
+  '&:hoverm &:focus': {
+    color: theme.colors.dddpink600,
   },
 }))
+
+function getButtonStylesForKind(kind: ButtonKinds, theme: Theme): CSSObject {
+  switch (kind) {
+    case 'primary':
+      return {
+        backgroundColor: theme.colors.dddpink,
+        color: theme.colors.white,
+
+        '&:hover, &:focus': {
+          backgroundColor: theme.colors.dddpink600,
+        },
+
+        '&:focus': {
+          boxShadow: `0 0 0 ${calcRem(theme.metrics.xs)} ${theme.colors.dddpink}`,
+        },
+      }
+    default:
+      return {
+        backgroundColor: theme.colors.grey300,
+        color: theme.colors.dddpink,
+        '&:hover, &:focus': {
+          backgroundColor: theme.colors.grey400,
+        },
+
+        '&:focus': {
+          boxShadow: `0 0 0 ${calcRem(theme.metrics.xs)} ${theme.colors.grey300}`,
+        },
+      }
+  }
+}
+
+interface StyledButtonAnchorProps {
+  kind: ButtonKinds
+  size?: Size
+}
+
+export const StyledButtonAnchor = styled('a', { shouldForwardProp: shouldStyledButtonForwardProps })<
+  StyledButtonAnchorProps
+>(({ theme, kind, size }) => ({
+  display: 'inline-block',
+  padding: calcRem(theme.metrics.md, theme.metrics.lg),
+  fontWeight: theme.weights.medium,
+  border: 0,
+  cursor: 'pointer',
+  outline: 0,
+  textDecoration: 'none',
+  textTransform: 'uppercase',
+  transition: 'background-color 0.2s linear',
+  ...getButtonStylesForKind(kind, theme),
+
+  ...conditionalStyles(size === 'lg', {
+    padding: calcRem(theme.metrics.lg, theme.metrics.xl),
+  }),
+
+  '&[disabled]': {
+    opacity: 0.65,
+    pointerEvents: 'none',
+  },
+}))
+
+export const StyledButton = StyledButtonAnchor.withComponent('button')

--- a/components/global/Button/Button.tsx
+++ b/components/global/Button/Button.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { StyledButton, StyledLinkButton } from './Button.styled'
+import { StyledButton, StyledLinkButton, StyledButtonAnchor } from './Button.styled'
 
 export type ButtonKinds = 'primary' | 'secondary' | 'tertiary' | 'inverse' | 'link'
-export type Size = 'small' | 'normal'
+export type Size = 'small' | 'normal' | 'lg'
 
 export interface ButtonProps
   extends React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {
@@ -18,3 +18,20 @@ export const Button: React.FC<ButtonProps> = props => {
     </Component>
   )
 }
+
+interface ButtonAnchorProps
+  extends React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> {
+  kind: ButtonKinds
+  size?: Size
+}
+
+export const ButtonAnchor: React.FC<ButtonAnchorProps> = ({
+  children,
+  kind = 'secondary',
+  size = 'normal',
+  ...props
+}) => (
+  <StyledButtonAnchor kind={kind} size={size} {...props}>
+    {children}
+  </StyledButtonAnchor>
+)

--- a/components/utils/styles/theme.ts
+++ b/components/utils/styles/theme.ts
@@ -6,8 +6,10 @@ export const theme = {
     black: '#000',
     grey800: '#4E5052',
     grey300: '#E6EAEA',
+    grey400: '#bec1c0',
     grey100: '#F4F7F6',
     dddpink: '#D2438E',
+    dddpink600: '#be2373',
     ///////////////////////////
     primary: '#008554',
     primary150: '#003924',


### PR DESCRIPTION
Refactors the button component for the new styling, plus adds an anchor
which looks like a button. Without Bootstrap the CSS could be shrunk quite a lot as we aren't battling that any longer.