### PR TITLE
Fixes homepage horizontal scroll

### DIFF
--- a/components/global/Footer/footer.tsx
+++ b/components/global/Footer/footer.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from 'react'
 import { Conference, MenuItem, Socials } from '../../../config/types'
-import { StyledContainer } from '../Container/Container.styled'
 import SocialLinks from '../socialLinks'
 import { StyledFooterCopyright } from './Footer.styled'
 import FooterNav from './footerNav'
@@ -13,12 +12,10 @@ interface FooterArgs {
 
 export const Footer: FC<FooterArgs> = ({ menu, socials, conference }) => (
   <footer>
-    <StyledContainer>
-      <FooterNav menu={menu} />
-      <SocialLinks socials={socials} />
-      <StyledFooterCopyright>
-        Copyright &copy; {new Date().getFullYear()} {conference.Organiser.Name}
-      </StyledFooterCopyright>
-    </StyledContainer>
+    <FooterNav menu={menu} />
+    <SocialLinks socials={socials} />
+    <StyledFooterCopyright>
+      Copyright &copy; {new Date().getFullYear()} {conference.Organiser.Name}
+    </StyledFooterCopyright>
   </footer>
 )

--- a/components/importantDates.tsx
+++ b/components/importantDates.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Action, Conference } from '../config/types'
 import ActionButton from './actionButton'
-import { StyledContainer } from './global/Container/Container.styled'
 import { ImportantDatesList } from './ImportantDatesList/importantDatesList'
 import { CurrentDate } from './utils/dateTimeProvider'
 
@@ -12,18 +11,16 @@ export interface ImportantDatesProps {
 }
 
 export default ({ conference, actions, currentDate }: ImportantDatesProps) => (
-  <section className="important-dates">
-    <StyledContainer>
-      <h2>Important Dates</h2>
+  <section>
+    <h2>Important Dates</h2>
 
-      <ImportantDatesList conference={conference} currentDate={currentDate} />
+    <ImportantDatesList conference={conference} currentDate={currentDate} />
 
-      <div className="what-now">
-        <h2>What now?</h2>
-        {actions.map(a => (
-          <ActionButton action={a} key={a.Title} />
-        ))}
-      </div>
-    </StyledContainer>
+    <div className="what-now">
+      <h2>What now?</h2>
+      {actions.map((a) => (
+        <ActionButton action={a} key={a.Title} />
+      ))}
+    </div>
   </section>
 )


### PR DESCRIPTION
The change to grid layout means we don't need the container component on
the homepage (and likely other pages). PR removes it from components
affecting the homepage layout.