### PR TITLE
Updates dates and COVID-19 statement

### DIFF
--- a/config/conference.ts
+++ b/config/conference.ts
@@ -13,25 +13,19 @@ import venue from './venue'
 const name = 'DDD Perth'
 const tagLine = `${name} is an inclusive non-profit conference for the Perth software community`
 
-const hideDate = false
+const hideDate = true
 const ticketPurchasingOptions = TicketPurchasingOptions.WaitListOpen
-const date = moment.parseZone('2020-08-01T08:00+08:00')
+const date = moment.parseZone('2021-08-14T08:00+08:00')
 const endDate = date.clone().add(12, 'h')
 const currentInstance = parseInt(date.format('YYYY'), 10)
 const firstInstance = 2015
-const registrationOpenFrom = moment.parseZone('2020-04-30T08:00:00+08:00')
-const registrationOpenUntil = hideDate
-  ? null
-  : date
-      .clone()
-      .add(-1, 'd')
-      .startOf('day')
-      .add(17, 'h')
-const presentationSubmissionsOpenFrom = moment.parseZone('2020-04-24T08:00:00+08:00')
-const presentationSubmissionsOpenUntil = moment.parseZone('2020-05-31T23:59:59+08:00')
-const votingOpenFrom = moment.parseZone('2020-06-05T17:00:00+08:00')
-const votingOpenUntil = moment.parseZone('2020-06-14T23:59:59+08:00')
-const agendaPublishedFrom = moment.parseZone('2020-07-17T17:00:00+08:00')
+const registrationOpenFrom = moment.parseZone('2021-04-30T08:00:00+08:00')
+const registrationOpenUntil = hideDate ? null : date.clone().add(-1, 'd').startOf('day').add(17, 'h')
+const presentationSubmissionsOpenFrom = moment.parseZone('2021-04-24T08:00:00+08:00')
+const presentationSubmissionsOpenUntil = moment.parseZone('2021-05-31T23:59:59+08:00')
+const votingOpenFrom = moment.parseZone('2021-06-05T17:00:00+08:00')
+const votingOpenUntil = moment.parseZone('2021-06-14T23:59:59+08:00')
+const agendaPublishedFrom = moment.parseZone('2021-07-17T17:00:00+08:00')
 const feedbackOpenFrom = date.clone()
 const feedbackOpenUntil = endDate
 const importantDates: ImportantDate[] = [
@@ -190,7 +184,7 @@ const Conference: IConference = {
     },
   },
 
-  ImportantDates: orderBy(importantDates, i => i.Date),
+  ImportantDates: orderBy(importantDates, (i) => i.Date),
 
   Sponsors: SponsorData,
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,39 +32,14 @@ class Index extends React.Component<IndexProps & WithPageMetadataProps> {
       <Page pageMetadata={this.props.pageMetadata} isHome={true} title="Home">
         <div className="container">
           <Alert kind="info">
-            <h2>Website Statement</h2>
+            <p>The DDD Perth Committee has regretfully postponed the 2019 conference to 2020.</p>
             <p>
-              <time dateTime="2020-03-15">15th March 2020</time>
+              The safety of all participants, from sponsors to speakers to attendees to volunteers, is our priority, and
+              we will continue to find ways to connect and support the wider Perth community at this challenging time.
             </p>
             <p>
-              DDD Perth is currently scheduled for <time dateTime="2020-08-01">August 1, 2020</time>.
-            </p>
-            <p>
-              The committee responsible for running DDD Perth is actively and continuously monitoring the COVID-19 virus
-              outbreak in line with Australian Government public health advice and the World Health Organization (WHO).
-              All committee meetings are being held remotely.
-            </p>
-            <p>
-              As of <time dateTime="2020-03-15">March 15</time>, the conference is over four months away, which is
-              simultaneously a long way away and very close, considering today's rapidly evolving situation.
-            </p>
-            <p>
-              We are aware of the current ban on events over 500 people and will adopt a cautious approach towards
-              confirming the event. The safety of all participants, from sponsors to speakers to attendees to
-              volunteers, is our priority.
-            </p>
-            <p>
-              It is our opinion that we should confirm our event date before tickets open and as such will decide
-              whether to postpone the event before <time dateTime="2020-04-30">April 30, 2020</time>.
-            </p>
-            <p>
-              Our sponsors are aware of our current position, and we thank them for their continued support of our
-              conference and community events.
-            </p>
-            <p>
-              As our planning progresses, we will continue to monitor and adapt the conference based on the situation.
-              You can read the latest on our website at any time, or contact us via the website should you have any
-              concerns.
+              If you have any concerns that you feel DDD Perth can help with, we encourage you to contact us via the
+              website.
             </p>
             <p>
               The Australian Department of Health recommends that everyone should practise good hygiene to protect

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,7 +32,7 @@ class Index extends React.Component<IndexProps & WithPageMetadataProps> {
       <Page pageMetadata={this.props.pageMetadata} isHome={true} title="Home">
         <div className="container">
           <Alert kind="info">
-            <p>The DDD Perth Committee has regretfully postponed the 2019 conference to 2020.</p>
+            <p>The DDD Perth Committee has regretfully postponed the 2020 conference to 2021.</p>
             <p>
               The safety of all participants, from sponsors to speakers to attendees to volunteers, is our priority, and
               we will continue to find ways to connect and support the wider Perth community at this challenging time.


### PR DESCRIPTION
Due to the conference being postponed we need to push the dates back
until next year. Have set hideDate to true but that only handles the
conference day. The other dates are a bit of a best guess based on this
year's dates.