### PR TITLE
Fixes logo missing label error

### DIFF
--- a/components/global/Header/Header.tsx
+++ b/components/global/Header/Header.tsx
@@ -14,7 +14,7 @@ export const Header: React.FC<HeaderProps> = ({ metadata }) => (
   <StyledHeader>
     <NavToggle />
     <Link passHref={true} href="/">
-      <StyledAnchor>
+      <StyledAnchor aria-label="DDD Perth">
         <DDDLogo />
       </StyledAnchor>
     </Link>


### PR DESCRIPTION
Fixes the lighthouse error for no label being accessible on the link by
using the aria-label property.