### PR TITLE
Adds Navigation click outside support

### DIFF
--- a/components/global/Nav/Nav.styled.tsx
+++ b/components/global/Nav/Nav.styled.tsx
@@ -22,7 +22,7 @@ StyledNav.displayName = 'StyledNav'
 export const StyledNavList = styled('ul')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
-  width: '64vw',
+  width: '40vw',
   height: '100vh',
   minWidth: 280,
   padding: calcRem(0, theme.metrics.md),

--- a/components/global/Nav/Nav.tsx
+++ b/components/global/Nav/Nav.tsx
@@ -85,6 +85,25 @@ export const Nav: React.FC<NavProps> = ({ menu }) => {
     }
   }, [expanded])
 
+  React.useEffect(() => {
+    function documentClickHandler(evt: MouseEvent | TouchEvent) {
+      if (containerRef.current && evt.target instanceof Node && !containerRef.current.contains(evt.target)) {
+        dispatch('close')
+        setStatus('closing')
+      }
+    }
+
+    if (expanded) {
+      document.addEventListener('click', documentClickHandler)
+      document.addEventListener('touchstart', documentClickHandler)
+    }
+
+    return () => {
+      document.removeEventListener('click', documentClickHandler)
+      document.removeEventListener('touchstart', documentClickHandler)
+    }
+  }, [expanded, dispatch])
+
   return (
     <StyledNav status={status} ref={containerRef}>
       <StyledNavList id={id} aria-expanded={status === 'open'} ref={navRef} tabIndex={-1}>


### PR DESCRIPTION
Fixes #305 by adding event handlers that respond to clicking outside of
the navigation container, thus triggering a close event.