### PR TITLE
Update CFP content

### DIFF
--- a/pages/cfp.tsx
+++ b/pages/cfp.tsx
@@ -88,11 +88,7 @@ const CFPPage: NextPage<WithPageMetadataProps> = ({ pageMetadata }) => {
 
       <StyledPara>Other things to note for presenters:</StyledPara>
       <StyledList>
-        <li>
-          Speakers get free entry into the event; flights and accommodation for speakers are not normally covered
-          (outside of keynote speakers), but if that's a limitation that stops you from speaking then please{' '}
-          <a href={`mailto:${conference.ContactEmail}`}>let us know</a> and we'll reach out to discuss options.
-        </li>
+        <li>Speakers get free entry into the event</li>
         <li>You will likely be speaking to an audience of between 50-150 people.</li>
         <li>
           We are not interested in sales/vendor pitch presentations although you are welcome to have a slide or two


### PR DESCRIPTION
Removes references to travel and accommodation which aren't possible
at the moment.

[Requested in Teams by Amy](https://teams.microsoft.com/l/message/19:39b6e800540144018f685e906138d623@thread.skype/1619753974416?tenantId=f33985f0-9c96-4413-bda6-fb838481224b&groupId=e5193b22-958b-49a7-aaf1-d7c799ab041f&parentMessageId=1619753974416&teamName=Data%2C%20analytics%2C%20website%20and%20IT&channelName=General&createdTime=1619753974416)

### Testing
* View http://localhost:3000/cfp
* The first dot point under "Other things to note for presenters" should no longer mention travel and accommodation