### PR TITLE
Rename Go to filters

### DIFF
--- a/components/utils/styles/global.ts
+++ b/components/utils/styles/global.ts
@@ -2,6 +2,9 @@ import { css } from '@emotion/core'
 import { theme } from './theme'
 
 export const globalCSS = css`
+  html {
+    scroll-behavior: smooth;
+  }
   body {
     font-family: ${theme.fonts.main};
     color: ${theme.colors.grey800};

--- a/components/voting.tsx
+++ b/components/voting.tsx
@@ -264,7 +264,7 @@ export default class Voting extends React.PureComponent<VotingProps, VotingState
 
     return (
       <React.Fragment>
-        <div ref={this.votingTopRef} />
+        <div id="top" ref={this.votingTopRef} />
         <StyledVotingPanel>
           <div
             className="voting-control form-inline"
@@ -283,7 +283,7 @@ export default class Voting extends React.PureComponent<VotingProps, VotingState
               {!this.state.submitted && (
                 <React.Fragment>
                   <h3>Vote</h3>
-                  <a href="#">Go to filters</a>
+                  <a href="#top">Top of page</a>
                 </React.Fragment>
               )}
             </StyledVoteHeader>


### PR DESCRIPTION
Renames go to filters to top of page and makes the scrolling smooth as
butter

### Testing 
* Head to the voting page, you'll need to open voting in the testing menu
* See the new button label
* Scroll down a bit and select it
* scroll smoooooooothly to the top