### PR TITLE
Updates 2020 agenda

### DIFF
--- a/pages/agenda/2020.tsx
+++ b/pages/agenda/2020.tsx
@@ -7,17 +7,9 @@ import { StyledPara } from 'components/global/text'
 export default withPageMetadata((props: WithPageMetadataProps) => (
   <PageWithSidebar metadata={props.pageMetadata} title="2020 Conference" description="DDDPerth Conference 2020">
     <h1>DDD Perth 2020</h1>
-    <StyledPara>The DDD Perth Committee has regretfully postponed the 2020 conference to 2021.</StyledPara>
     <StyledPara>
-      The safety of all participants, from sponsors to speakers to attendees to volunteers, is our priority, and we will
-      continue to find ways to connect and support the wider Perth community at this challenging time.
-    </StyledPara>
-    <StyledPara>
-      If you have any concerns that you feel DDD Perth can help with, we encourage you to contact us via the website.
-    </StyledPara>
-    <StyledPara>
-      The Australian Department of Health recommends that everyone should practise good hygiene to protect against
-      infections.
+      DDD Perth 2020 did not happen. The safety of all participants, from sponsors to speakers to attendees to
+      volunteers, is our priority and we felt we could better serve our community by postponing the event.
     </StyledPara>
 
     <AllAgendas


### PR DESCRIPTION
Updates the content for the 20202 agenda

### Testing
* View http://localhost:3000/agenda/2020
* Compare the [content to what's in teams](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/_djb2_msteams_prefix_3440068617?webUrl=https%3a%2f%2ftasks.office.com%2ff33985f0-9c96-4413-bda6-fb838481224b%2fHome%2fPlanViews%2fAufgKebEYUqODDxYHkBqdcgAAyTA%3fType%3dPlanLink%26Channel%3dTeamsTab&label=Add+new+page+for+https%3a%2f%2fdddperth.com%2fagenda%2f2020+in+Content+Updates&context=%7b%0d%0a++%22subEntityId%22%3a+%22vKDwdSnE-Um5bskUATUy1cgAA2Ab%22%2c%0d%0a++%22channelId%22%3a+%2219%3a39b6e800540144018f685e906138d623%40thread.skype%22%0d%0a%7d&tenantId=f33985f0-9c96-4413-bda6-fb838481224b) 