### PR TITLE
ActionBar Link and Unit tests

### DIFF
--- a/components/ActionBar/ActionBar.test.tsx
+++ b/components/ActionBar/ActionBar.test.tsx
@@ -1,11 +1,66 @@
 import React from 'react'
 import { render, screen } from 'test/test-util'
 import { ActionBar } from './ActionBar'
+import conference from 'config/conference'
+import { add } from 'date-fns'
+import { axe } from 'jest-axe'
+import { TicketPurchasingOptions } from 'config/types'
+
+function renderActionBar(date?: Date) {
+  if (date) {
+    jest.setSystemTime(date)
+  }
+
+  const utils = render(<ActionBar />)
+
+  return {
+    date,
+    ...utils,
+  }
+}
 
 describe('<ActionBar />', () => {
-  it('renders correctly', () => {
-    render(<ActionBar />)
+  beforeAll(() => {
+    jest.useFakeTimers()
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
+  test('renders', () => {
+    renderActionBar()
 
     expect(screen.getByRole('list')).toBeInTheDocument()
+  })
+
+  test('Show link when accepting presentations', () => {
+    renderActionBar(add(conference.PresentationSubmissionsOpenFrom, { days: 1 }))
+
+    expect(screen.getByText(/submit presentation/i)).toBeInTheDocument()
+  })
+
+  test('Show link when voting opens', () => {
+    renderActionBar(add(conference.VotingOpenFrom, { minutes: 1 }))
+
+    expect(screen.getByText(/vote for/i)).toBeInTheDocument()
+  })
+
+  test('Show link when registration opens', () => {
+    const originalValue = conference.TicketPurchasingOptions
+    conference.TicketPurchasingOptions = TicketPurchasingOptions.OnSale
+    renderActionBar(add(conference.RegistrationOpenFrom, { minutes: 1 }))
+
+    expect(screen.getByText(/purchase/i)).toBeInTheDocument()
+
+    conference.TicketPurchasingOptions = originalValue
+  })
+})
+
+describe('<ActionBar/> a11y', () => {
+  test('Has no violations', async () => {
+    const { container } = renderActionBar()
+
+    expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/components/ActionBar/ActionBar.tsx
+++ b/components/ActionBar/ActionBar.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Link from 'next/link'
 import { ButtonAnchor } from 'components/global/Button/Button'
 import { StyledActionBarContainer } from './ActionBar.styled'
 import getConferenceActions from 'config/actions'
@@ -14,16 +15,20 @@ export const ActionBar = (): JSX.Element => {
       <ul>
         {secondaryAction && (
           <li>
-            <ButtonAnchor href={secondaryAction.Url} kind="secondary" size="lg">
-              {secondaryAction.Title}
-            </ButtonAnchor>
+            <Link href={secondaryAction.Url}>
+              <ButtonAnchor kind="secondary" size="lg">
+                {secondaryAction.Title}
+              </ButtonAnchor>
+            </Link>
           </li>
         )}
         {primaryAction && (
           <li>
-            <ButtonAnchor href={primaryAction.Url} kind="primary" size="lg">
-              {primaryAction.Title}
-            </ButtonAnchor>
+            <Link href={primaryAction.Url}>
+              <ButtonAnchor kind="primary" size="lg">
+                {primaryAction.Title}
+              </ButtonAnchor>
+            </Link>
           </li>
         )}
       </ul>


### PR DESCRIPTION
Updates ActionBar to use Next's Link component to better support
client side navigation.

Adds unit tests to ensure the correct links display during the time
they are meant to.

### Test Plan

- [ ] Unit tests should pass
- [ ] Using the component will be a client side navigation event rather than server side
