### PR TITLE
Enable Testing Control on server side

### DIFF
--- a/components/TestingControl/TestingControl.tsx
+++ b/components/TestingControl/TestingControl.tsx
@@ -7,10 +7,16 @@ import dateTimeProvider from 'components/utils/dateTimeProvider'
 import { StyledButton, StyledTestingControl, StyledTestingHeading, StyledTestingPanel } from './TestingControl.styled'
 import { sub, format } from 'date-fns'
 import { useConfig } from 'Context/Config'
+import Cookies from 'js-cookie'
+import { TestingControlCookie } from './TestingControlConsts'
 
 export const TestingControl = (): JSX.Element => {
   const { conference, currentDate } = useConfig()
   const [show, setShow] = useState(false)
+
+  function storeTime(dateOverride: Date) {
+    Cookies.set(TestingControlCookie, dateOverride.toISOString())
+  }
 
   const resetVote = () => {
     localStorage.removeItem('ddd-voting-submitted')
@@ -19,6 +25,7 @@ export const TestingControl = (): JSX.Element => {
 
   const reset = () => {
     dateTimeProvider.reset()
+    Cookies.remove(TestingControlCookie)
 
     conference.Sponsors = SponsorData
     conference.TicketPurchasingOptions = TicketPurchasingOptions.SoldOut
@@ -37,29 +44,28 @@ export const TestingControl = (): JSX.Element => {
         <StyledTestingPanel>
           <StyledButton
             kind="primary"
-            onClick={() => dateTimeProvider.setDateTo(sub(conference.PresentationSubmissionsOpenFrom, { days: 1 }))}
+            onClick={() => {
+              storeTime(sub(conference.PresentationSubmissionsOpenFrom, { days: 1 }))
+            }}
           >
             Pre-CFP
           </StyledButton>
-          <StyledButton
-            kind="secondary"
-            onClick={() => dateTimeProvider.setDateTo(conference.PresentationSubmissionsOpenFrom)}
-          >
+          <StyledButton kind="secondary" onClick={() => storeTime(conference.PresentationSubmissionsOpenFrom)}>
             CFP open
           </StyledButton>
-          <StyledButton kind="tertiary" onClick={() => dateTimeProvider.setDateTo(conference.VotingOpenFrom)}>
+          <StyledButton kind="tertiary" onClick={() => storeTime(conference.VotingOpenFrom)}>
             Voting open
           </StyledButton>
-          <StyledButton kind="tertiary" onClick={() => dateTimeProvider.setDateTo(conference.VotingOpenUntil)}>
+          <StyledButton kind="tertiary" onClick={() => storeTime(conference.VotingOpenUntil)}>
             Voting closed
           </StyledButton>
-          <StyledButton kind="inverse" onClick={() => dateTimeProvider.setDateTo(conference.AgendaPublishedFrom)}>
+          <StyledButton kind="inverse" onClick={() => storeTime(conference.AgendaPublishedFrom)}>
             Agenda published
           </StyledButton>
-          <StyledButton kind="primary" onClick={() => dateTimeProvider.setDateTo(conference.Date)}>
+          <StyledButton kind="primary" onClick={() => storeTime(conference.Date)}>
             On the day
           </StyledButton>
-          <StyledButton kind="primary" onClick={() => dateTimeProvider.setDateTo(conference.EndDate)}>
+          <StyledButton kind="primary" onClick={() => storeTime(conference.EndDate)}>
             Conference over
           </StyledButton>
           <StyledButton

--- a/components/TestingControl/TestingControlConsts.ts
+++ b/components/TestingControl/TestingControlConsts.ts
@@ -1,0 +1,1 @@
+export const TestingControlCookie = 'testing-control-time'

--- a/components/TestingControl/TestingControlUtils.ts
+++ b/components/TestingControl/TestingControlUtils.ts
@@ -1,0 +1,6 @@
+import { NextApiRequestCookies } from 'next/dist/server/api-utils'
+import { TestingControlCookie } from './TestingControlConsts'
+
+export function getTestingControlDate(cookies: NextApiRequestCookies) {
+  return cookies[TestingControlCookie]
+}

--- a/components/utils/getCommonServerSideProps.ts
+++ b/components/utils/getCommonServerSideProps.ts
@@ -1,0 +1,20 @@
+import { TestingControlCookie } from 'components/TestingControl/TestingControlConsts'
+import Conference from 'config/conference'
+import getConferenceDates from 'config/dates'
+import { GetServerSidePropsContext, PreviewData } from 'next/types'
+import { ParsedUrlQuery } from 'querystring'
+import dateTimeProvider from './dateTimeProvider'
+
+export function getCommonServerSideProps(context: GetServerSidePropsContext<ParsedUrlQuery, PreviewData>) {
+  const testingDateCookie = context.req.cookies[TestingControlCookie]
+
+  if (testingDateCookie) {
+    dateTimeProvider.setDateTo(new Date(testingDateCookie))
+  }
+
+  const dates = getConferenceDates(Conference, dateTimeProvider.now())
+
+  return {
+    dates,
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "husky": "^7.0.4",
         "jest": "^27.5.1",
         "jest-axe": "^6.0.0",
+        "js-cookie": "^3.0.1",
         "lint-staged": "^12.3.5",
         "prettier": "^2.5.1",
         "rimraf": "^3.0.2",
@@ -5591,6 +5592,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/js-tokens": {
@@ -12627,6 +12637,12 @@
           }
         }
       }
+    },
+    "js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "husky": "^7.0.4",
     "jest": "^27.5.1",
     "jest-axe": "^6.0.0",
+    "js-cookie": "^3.0.1",
     "lint-staged": "^12.3.5",
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",

--- a/pages/agenda.tsx
+++ b/pages/agenda.tsx
@@ -2,15 +2,14 @@ import React from 'react'
 import AllAgendas from 'components/allAgendas'
 import { CurrentAgenda } from 'components/currentAgenda'
 import { Sponsors } from 'components/Sponsors/sponsors'
-import dateTimeProvider from 'components/utils/dateTimeProvider'
 import { fetchSessions } from 'components/utils/useSessions'
 import Conference from 'config/conference'
-import getConferenceDates from 'config/dates'
 import { Session, SponsorType } from 'config/types'
 import { Main } from 'layouts/main'
 import { format } from 'date-fns'
 import { GetServerSideProps, NextPage } from 'next'
 import { useConfig } from 'Context/Config'
+import { getCommonServerSideProps } from 'components/utils/getCommonServerSideProps'
 
 interface AgendaPageProps {
   sessions?: Session[]
@@ -65,7 +64,7 @@ const AgendaPage: NextPage<AgendaPageProps> = ({ sessions, sessionId }) => {
 }
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const dates = getConferenceDates(Conference, dateTimeProvider.now())
+  const { dates } = getCommonServerSideProps(context)
 
   if (!dates.VotingFinished) {
     return { redirect: { destination: `/agenda/${Conference.PreviousInstance}`, permanent: false } }

--- a/pages/cfp.tsx
+++ b/pages/cfp.tsx
@@ -2,13 +2,11 @@ import React from 'react'
 import { GetServerSideProps, NextPage } from 'next'
 import Link from 'next/link'
 import { StyledList, Text } from 'components/global/text'
-import dateTimeProvider from 'components/utils/dateTimeProvider'
-import Conference from 'config/conference'
-import getConferenceDates from 'config/dates'
 import { PageWithSidebar } from 'layouts/withSidebar'
 import { ButtonAnchor } from 'components/global/Button/Button'
 import { format } from 'date-fns'
 import { useConfig } from 'Context/Config'
+import { getCommonServerSideProps } from 'components/utils/getCommonServerSideProps'
 
 const CFPPage: NextPage = () => {
   const { conference, dates } = useConfig()
@@ -119,8 +117,8 @@ const CFPPage: NextPage = () => {
   )
 }
 
-export const getServerSideProps: GetServerSideProps = async () => {
-  const dates = getConferenceDates(Conference, dateTimeProvider.now())
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { dates } = getCommonServerSideProps(context)
 
   if (!dates.AcceptingPresentations) {
     return { redirect: { destination: '/', permanent: false } }

--- a/pages/conference-feedback.tsx
+++ b/pages/conference-feedback.tsx
@@ -17,14 +17,12 @@ import { defaultFormState, formReducer } from 'components/Feedback/FormReducers'
 import { Alert } from 'components/global/Alert/Alert'
 import { logException } from 'components/global/analytics'
 import { StyledContainer } from 'components/global/Container/Container.styled'
-import dateTimeProvider from 'components/utils/dateTimeProvider'
 import { getLocalStoredName, storageKey, StorageKeys } from 'components/utils/storageKey'
 import { useDeviceId } from 'components/utils/useDeviceId'
 import { useForm } from 'components/utils/useForm'
-import Conference from 'config/conference'
-import getConferenceDates from 'config/dates'
 import { Main } from 'layouts/main'
 import { useConfig } from 'Context/Config'
+import { getCommonServerSideProps } from 'components/utils/getCommonServerSideProps'
 
 interface FeedbackFormState {
   name: string | undefined
@@ -169,8 +167,8 @@ const ConferenceFeedback: NextPage = () => {
   )
 }
 
-export const getServerSideProps: GetServerSideProps = async () => {
-  const dates = getConferenceDates(Conference, dateTimeProvider.now())
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { dates } = getCommonServerSideProps(context)
 
   if (!dates.AcceptingFeedback) {
     return { redirect: { destination: '/', permanent: false } }

--- a/pages/feedback.tsx
+++ b/pages/feedback.tsx
@@ -22,18 +22,16 @@ import { SessionInput } from 'components/Feedback/SessionInput'
 import { Alert } from 'components/global/Alert/Alert'
 import { logException } from 'components/global/analytics'
 import { StyledContainer } from 'components/global/Container/Container.styled'
-import dateTimeProvider from 'components/utils/dateTimeProvider'
 import { getLocalStoredName, storageKey, StorageKeys } from 'components/utils/storageKey'
 import { useDeviceId } from 'components/utils/useDeviceId'
 import { useForm } from 'components/utils/useForm'
 import { useSessionGroups } from 'components/utils/useSessionGroups'
 import { fetchSessions } from 'components/utils/useSessions'
-import Conference from 'config/conference'
-import getConferenceDates from 'config/dates'
 import { Session } from 'config/types'
 import { Main } from 'layouts/main'
 import { format } from 'date-fns'
 import { useConfig } from 'Context/Config'
+import { getCommonServerSideProps } from 'components/utils/getCommonServerSideProps'
 
 interface FeedbackFormState {
   name: string | undefined
@@ -240,8 +238,8 @@ const Feedback: NextPage<FeedbackProps> = ({ sessions }) => {
   )
 }
 
-export const getServerSideProps: GetServerSideProps = async () => {
-  const dates = getConferenceDates(Conference, dateTimeProvider.now())
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { dates } = getCommonServerSideProps(context)
 
   if (!dates.AcceptingFeedback) {
     return { redirect: { destination: '/', permanent: false } }

--- a/pages/tickets.tsx
+++ b/pages/tickets.tsx
@@ -2,9 +2,7 @@ import Error from 'next/error'
 import React from 'react'
 import { NextPage, GetServerSideProps } from 'next'
 import { FaqList } from 'components/FAQList/FaqList'
-import dateTimeProvider from 'components/utils/dateTimeProvider'
 import Conference from 'config/conference'
-import getConferenceDates from 'config/dates'
 import getFaqs from 'config/faqs'
 import { TicketPurchasingOptions, TicketsProvider } from 'config/types'
 import { Tito } from 'components/Tickets/Tito'
@@ -12,6 +10,7 @@ import { Main } from 'layouts/main'
 import { Eventbrite } from 'components/Tickets/Eventbrite'
 import { Text } from 'components/global/text'
 import { useConfig } from 'Context/Config'
+import { getCommonServerSideProps } from 'components/utils/getCommonServerSideProps'
 
 const TicketPage: NextPage = () => {
   const { conference, dates } = useConfig()
@@ -45,11 +44,9 @@ const TicketPage: NextPage = () => {
   )
 }
 
-export const getServerSideProps: GetServerSideProps = async () => {
-  if (
-    !getConferenceDates(Conference, dateTimeProvider.now()).RegistrationOpen &&
-    Conference.TicketPurchasingOptions !== TicketPurchasingOptions.WaitListOpen
-  ) {
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { dates } = getCommonServerSideProps(context)
+  if (!dates.RegistrationOpen && Conference.TicketPurchasingOptions !== TicketPurchasingOptions.WaitListOpen) {
     return { notFound: true }
   }
 

--- a/pages/vote/elo.tsx
+++ b/pages/vote/elo.tsx
@@ -1,3 +1,4 @@
+import { GetServerSideProps } from 'next'
 import { Button } from 'components/global/Button/Button'
 import { EloVote } from 'components/Voting/Elo'
 import { EloSession } from 'config/types'
@@ -5,10 +6,8 @@ import { useConfig } from 'Context/Config'
 import { Main } from 'layouts/main'
 import { useEffect, useState } from 'react'
 import { getSessionId } from 'components/global/analytics'
-import getConferenceDates from 'config/dates'
-import dateTimeProvider from 'components/utils/dateTimeProvider'
-import Conference from 'config/conference'
 import { logEvent, logException } from 'components/global/analytics'
+import { getCommonServerSideProps } from 'components/utils/getCommonServerSideProps'
 
 type SessionPair = {
   SubmissionA: EloSession
@@ -99,8 +98,9 @@ export default function Elo({ sessions }: EloProps): JSX.Element {
   )
 }
 
-export async function getServerSideProps() {
-  const dates = getConferenceDates(Conference, dateTimeProvider.now())
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { dates } = getCommonServerSideProps(context)
+
   if (!dates.VotingOpen) {
     return { notFound: true }
   }

--- a/pages/vote/index.tsx
+++ b/pages/vote/index.tsx
@@ -1,12 +1,10 @@
-import dateTimeProvider from 'components/utils/dateTimeProvider'
-import Conference from 'config/conference'
-import getConferenceDates from 'config/dates'
 import { GetServerSideProps, NextPage } from 'next'
 import { Main } from 'layouts/main'
 import { Session } from 'config/types'
 import React from 'react'
 import { VoteContent } from 'components/Voting/Content'
 import { useConfig } from 'Context/Config'
+import { getCommonServerSideProps } from 'components/utils/getCommonServerSideProps'
 
 type VotePageProps = {
   sessions: Session[]
@@ -22,8 +20,9 @@ const VotePage: NextPage<VotePageProps> = ({ sessions }) => {
   )
 }
 
-export const getServerSideProps: GetServerSideProps = async () => {
-  const dates = getConferenceDates(Conference, dateTimeProvider.now())
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { dates } = getCommonServerSideProps(context)
+
   if (!dates.VotingOpen) {
     return { notFound: true }
   }

--- a/pages/vote/voting.tsx
+++ b/pages/vote/voting.tsx
@@ -1,15 +1,13 @@
 import React from 'react'
 import { v4 as uuid } from 'uuid'
 import { logEvent, logException } from 'components/global/analytics'
-import dateTimeProvider from 'components/utils/dateTimeProvider'
 import Voting from 'components/voting'
-import Conference from 'config/conference'
-import getConferenceDates from 'config/dates'
 import { Conference as Conf, Session } from 'config/types'
 import { Main } from 'layouts/main'
 import { GetServerSideProps, NextPage } from 'next'
 import { Alert } from 'components/global/Alert/Alert'
 import { useConfig } from 'Context/Config'
+import { getCommonServerSideProps } from 'components/utils/getCommonServerSideProps'
 
 interface VoteProps {
   sessions?: Session[]
@@ -134,8 +132,9 @@ const VotePage: NextPage<VoteProps> = () => {
   )
 }
 
-export const getServerSideProps: GetServerSideProps = async () => {
-  const dates = getConferenceDates(Conference, dateTimeProvider.now())
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { dates } = getCommonServerSideProps(context)
+
   if (!dates.VotingOpen) {
     return { notFound: true }
   }


### PR DESCRIPTION
### Problem

The Testing Control previously worked on the client side but the logic
was moved to the server.

### Solution

To enable the testing control we will store a session cookie that the
server will check and set the date that way.

### Test Plan

- [ ] View the site
- [ ] Toggling the time with the testing util will write a cookie
- [ ] The cookie will enable you to use an area such as `/vote/elo`

### Device and Browser Testing

* Firefox