### PR TITLE
Fix minification of `testingMode` condition

### DIFF
--- a/Context/Config.tsx
+++ b/Context/Config.tsx
@@ -11,7 +11,7 @@ interface AppConfig {
   getSubmissionsUrl: string
   instrumentationKey: string
   submitVoteUrl: string
-  testingMode: boolean
+  testingMode: () => boolean
 }
 
 interface ConfigState {
@@ -47,7 +47,7 @@ const ConfigProvider = ({ children }: { children: React.ReactNode }): ReactEleme
           getSubmissionsUrl: process.env.NEXT_PUBLIC_GET_SUBMISSIONS_URL,
           instrumentationKey: process.env.NEXT_PUBLIC_APPINSIGHTS_INSTRUMENTATIONKEY,
           submitVoteUrl: process.env.NEXT_PUBLIC_SUBMIT_VOTE_URL,
-          testingMode: process.env.NEXT_PUBLIC_TESTING_MODE === 'true',
+          testingMode: () => testingModeEnv === 'true',
         },
         currentDate,
         dates: getConferenceDates(Conference, currentDate),
@@ -58,6 +58,12 @@ const ConfigProvider = ({ children }: { children: React.ReactNode }): ReactEleme
     </ConfigContext.Provider>
   )
 }
+
+// If we don't split up the `process.env.NEXT_PUBLIC_TESTING_MODE === 'true'` comparison
+// it is optimised away before env substitution in the pipeline.
+// The env subst expects `'#{TESTING_MODE}#' === 'true'`, but it was already reduced to `!1` (i.e. false) at build time.
+// Also, if this const is above the ConfigProvider it's optimised away
+const testingModeEnv = process.env.NEXT_PUBLIC_TESTING_MODE
 
 const useConfig = (): ConfigState => {
   const config = React.useContext(ConfigContext)

--- a/layouts/template.tsx
+++ b/layouts/template.tsx
@@ -35,7 +35,7 @@ export const Template = ({ children, title, description, image, showHero }: Temp
       {showHero && <Hero />}
       {children}
       <Footer />
-      {appConfig.testingMode && <TestingControl />}
+      {appConfig.testingMode() && <TestingControl />}
     </Fragment>
   )
 }

--- a/pages/feedback.tsx
+++ b/pages/feedback.tsx
@@ -115,7 +115,7 @@ const Feedback: NextPage<FeedbackProps> = ({ sessions }) => {
           </Alert>
         )}
 
-        {appConfig.testingMode && <FeedbackTimeTesting sessionGroups={allSessionGroups} />}
+        {appConfig.testingMode() && <FeedbackTimeTesting sessionGroups={allSessionGroups} />}
 
         {showForm && (
           <StyledForm onSubmit={handleSubmit}>


### PR DESCRIPTION
# Problem

The "testing control" wasn't appearing in test environment, even though the environment variables were set correctly.

It was working locally (with `npm run dev`), but not in the built version.

# Investigation

We'd tried adding to fix this in environment variables in Azure DevOps -- there was a `TESTING_MODE` variable, but in `.env.local` it was `NEXT_PUBLIC_TESTING_MODE`. So we added the `NEXT_PUBLIC_` version to Azure DevOps, but that didn't help.

There's a step in the pipeline that rewrites `.env.local` into `.env.production` and replaces whatever values were there with a string that will be replaced in another step, e.g. `NEXT_PUBLIC_TESTING_MODE=true` is turned into `NEXT_PUBLIC_TESTING_MODE=#{TESTING_MODE}#` (so it was supposed to be using `TESTING_MODE` after all).

The token substitution step is to enable "build once, deploy anywhere" -- otherwise we'd need to build once with test environment variables and once with prod environment variables. It looks for `#{something}#` and replaces it with the value of that environment variable.

I tried changing my `.env.local` to look more like what would end up in the pipeline, with `#{ENV}#`, and then running a build to see what happened.

I expected to see something like below.

```diff
appConfig: {
  //...
  submitVoteUrl: "#{NEXT_PUBLIC_SUBMIT_FEEDBACK_URL}#",
+  testingMode: "#{NEXT_PUBLIC_TESTING_MODE}#" === "true"
-  testingMode: !1
}
```

The string we were expecting doesn't appear at all, so the token substitution would never work.

At this point, I figured it was down to the minification in the Next.js build step, because it was comparing those two strings at build time and knew they would never be the same, hence it evaluated to `!1`, i.e. `false` (but with 3 fewer characters ... yay minification).

This kind of thing can be really useful to reduce the size of the code sent to the browser. For example, whole branches of code may be eliminated in "dead-code elimination".

# Solving it

Basically I needed to stop the Next.js build from seeing that comparison as something it could optimise away. 

I tried things like below, but other than the first one, they all seemed a lot less clear than what I ended up with

```
process.env.NEXT_PUBLIC_TESTING_MODE === 'true' + ''
process.env.NEXT_PUBLIC_TESTING_MODE === `${Math.random() >= 0}`
process.env.NEXT_PUBLIC_TESTING_MODE === ['t','r','u','e'].join('')
process.env.NEXT_PUBLIC_TESTING_MODE === String.fromCharCode(116,114,117,101)
```

In the end, I changed it so rather than comparing a string to a string directly, I split the two sides apart, so the environment variable is declared in one place, and ` === "true"` happens somewhere else. That seemed to be enough to stop it from being optimised away ... provided it was in the right place in the code.