### PR TITLE
Remove focus from VOTE button when the session changes

### DIFF
--- a/components/Voting/Elo.tsx
+++ b/components/Voting/Elo.tsx
@@ -23,12 +23,14 @@ export function EloVote({ sessionA, sessionB, onSessionChoice }: EloVoteProps): 
   return (
     <StyledEloVoteContainer>
       <EloChoice
+        key={sessionA.Id}
         session={sessionA}
         onChoice={() => {
           sessionChoiceHandler(sessionA.Id)
         }}
       />
       <EloChoice
+        key={sessionB.Id}
         session={sessionB}
         variant="secondary"
         onChoice={() => {


### PR DESCRIPTION
If you use keyboard to navigate to the vote buttons, when you press enter, it stays focused even though the talk has changed. Because it's focused, a user might accidentally or deliberately press enter before they've had a chance to read anything about the two sessions they're presented next.

The reason for this is that React reconciles the components as a change to the title and abstract, and perhaps a change to the click handler, but not a change to the button itself, so it stays focused. By adding a `key` of the session id, we tell React that these are totally different `EloChoice` components, not the same one with some different text, and it will unmount the old and mount the new when things change.

This will help prevent someone from
- spamming votes for either side, e.g. tab to the button and keep pressing enter
- accidentally voting for the next pair before having a chance to read and compare


Also fixes being scrolled part-way through the abstract for the new vote if you'd scrolled down on the previous one. When you click vote, everything scrolls back to the top


## Testing plan

- [ ] Select a vote button with keyboard
- [ ] Press enter repeatedly