### PR TITLE
Fix mobile overflow issue

### DIFF
--- a/components/Voting/EloVote.styled.tsx
+++ b/components/Voting/EloVote.styled.tsx
@@ -6,10 +6,14 @@ import { calcRem } from 'components/utils/styles/calcRem'
 export const StyledEloVoteContainer = styled('div')(({ theme }) => ({
   display: 'grid',
   gridTemplateColumns: `repeat(2, minmax(${calcRem(80)}, 1fr))`,
+  gridTemplateRows: '100%',
+  gridColumn: '1 / -1',
   gap: theme.metrics.md,
   inlineSize: '100%',
   maxInlineSize: calcRem(965),
   maxBlockSize: '60vh',
+  paddingInlineStart: calcRem(theme.metrics.sm),
+  paddingInlineEnd: calcRem(theme.metrics.sm),
   marginInlineStart: 'auto',
   marginInlineEnd: 'auto',
 
@@ -33,7 +37,6 @@ export const StyledEloChoice = styled('div')<StyledEloChoiceProps>(({ theme, var
   borderBlockStartWidth: 8,
   borderBlockStartStyle: 'solid',
   borderColor: variant === 'primary' ? theme.colors.primary : theme.colors.secondary,
-  overflow: 'hidden',
 
   [breakpoint('md')]: {
     padding: calcRem(theme.metrics.lg),


### PR DESCRIPTION
### Problem

During testing an issue was identified where the EloVote would overflow
the container.

### Solution

Resolves the issue by setting a proper height on the rows so the elements
are contained correctly.

Also gives the mobile layout more breathing room by stretching the full
width of the main container.

### Reference

[Team's task](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:39b6e800540144018f685e906138d623@thread.skype_p_ixgKZLqymUKGWO38bygy3MgADWdH_h_1645010228153?tenantId=f33985f0-9c96-4413-bda6-fb838481224b&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2Fvlk2sSWQ3k6C0ZTUwDu-fsgALc7r%22%2C%22channelId%22%3A%2219%3A39b6e800540144018f685e906138d623%40thread.skype%22%7D)

### Test Plan

- [ ] View the Elo Voting page - you'll need to use the testing tool to set the date
- [ ] At a mobile resolution, particularly in Safari, the content will no longer overflow the page (see Rob's screenshot in the linked task)

### Device and Browser Testing

* Firefox
* Safari
* Chrome
* Safari iPhone