### PR TITLE
TestingControl - show changes in time on front-end

### DIFF
--- a/components/TestingControl/TestingControl.tsx
+++ b/components/TestingControl/TestingControl.tsx
@@ -15,6 +15,7 @@ export const TestingControl = (): JSX.Element => {
   const [show, setShow] = useState(false)
 
   function storeTime(dateOverride: Date) {
+    dateTimeProvider.setDateTo(dateOverride)
     Cookies.set(TestingControlCookie, dateOverride.toISOString())
   }
 


### PR DESCRIPTION
When we added the cookie so that the server would recognise time we set in TestingControl, we inadvertently stopped it from reflecting that change in the user interface

Now when you change the date, you should see changes in which "Important dates" tiles are enabled on the home page, and what appears in the navigation menu

For example, changing to a voting open time means that "Vote" will appear in the menu, so you don't need to navigate to the voting page through the URL

https://user-images.githubusercontent.com/9972287/164143151-9494a52a-654e-4fc1-b423-852b6cd48e87.mov


