### PR TITLE
Handle newline in session abstracts for ELO vote

### DIFF
--- a/components/Voting/Elo.tsx
+++ b/components/Voting/Elo.tsx
@@ -1,3 +1,4 @@
+import { Text } from 'components/global/text'
 import { EloSession } from 'config/types'
 import { useMemo } from 'react'
 import {
@@ -61,7 +62,7 @@ function EloChoice({ session, variant = 'primary', onChoice }: EloChoiceProps) {
       <StyledSessionTitle>{session.Title}</StyledSessionTitle>
       <StyledSessionAbstract>
         {paragraphs.map((para) => (
-          <p key={para}>{para}</p>
+          <Text key={para}>{para}</Text>
         ))}
       </StyledSessionAbstract>
       <StyledVoteButton kind={variant} type="button" onClick={onVoteClick}>

--- a/components/Voting/Elo.tsx
+++ b/components/Voting/Elo.tsx
@@ -1,4 +1,5 @@
 import { EloSession } from 'config/types'
+import { useMemo } from 'react'
 import {
   StyledVoteButton,
   StyledEloVoteContainer,
@@ -52,10 +53,17 @@ function EloChoice({ session, variant = 'primary', onChoice }: EloChoiceProps) {
     onChoice(session)
   }
 
+  const abstract = session.Abstract
+  const paragraphs = useMemo(() => abstract.split('\n').filter((para) => !!para), [abstract])
+
   return (
     <StyledEloChoice variant={variant}>
       <StyledSessionTitle>{session.Title}</StyledSessionTitle>
-      <StyledSessionAbstract>{session.Abstract}</StyledSessionAbstract>
+      <StyledSessionAbstract>
+        {paragraphs.map((para) => (
+          <p key={para}>{para}</p>
+        ))}
+      </StyledSessionAbstract>
       <StyledVoteButton kind={variant} type="button" onClick={onVoteClick}>
         Pick Me
       </StyledVoteButton>

--- a/components/Voting/EloVote.styled.tsx
+++ b/components/Voting/EloVote.styled.tsx
@@ -58,12 +58,8 @@ export const StyledSessionTitle = styled('h3')(({ theme }) => ({
 export const StyledSessionAbstract = styled('div')(({ theme }) => ({
   flex: 1,
   marginBlockEnd: calcRem(theme.metrics.md),
-  color: '#333',
   overflow: 'hidden',
   overflowY: 'auto',
-  '& p:not(:last-child)': {
-    marginBlockEnd: calcRem(theme.metrics.sm),
-  },
 }))
 
 type StyledVoteButtonProps = {

--- a/components/Voting/EloVote.styled.tsx
+++ b/components/Voting/EloVote.styled.tsx
@@ -61,6 +61,9 @@ export const StyledSessionAbstract = styled('div')(({ theme }) => ({
   color: '#333',
   overflow: 'hidden',
   overflowY: 'auto',
+  '& p:not(:last-child)': {
+    marginBlockEnd: calcRem(theme.metrics.sm),
+  },
 }))
 
 type StyledVoteButtonProps = {

--- a/components/utils/styles/theme.ts
+++ b/components/utils/styles/theme.ts
@@ -94,7 +94,7 @@ export const theme = {
     /** xxl: 40 */
     xxl: 40,
   },
-}
+} as const
 
 export type DDDTheme = typeof theme
 


### PR DESCRIPTION
This is a bit selfish because my own submissions had two paragraphs and I noticed they weren't appearing

|Before|After|
|---|---|
|<img width="296" alt="Screen Shot 2022-04-21 at 00 05 22" src="https://user-images.githubusercontent.com/9972287/164274331-41d389d5-fd60-4817-bb79-0466f83791d5.png">|<img width="298" alt="Screen Shot 2022-04-21 at 00 05 04" src="https://user-images.githubusercontent.com/9972287/164274362-baa89291-fa70-4982-823a-12736e9842e8.png">|