### PR TITLE
Stack ELO vote cards on mobile

### DIFF
--- a/components/Voting/EloVote.styled.tsx
+++ b/components/Voting/EloVote.styled.tsx
@@ -5,20 +5,21 @@ import { calcRem } from 'components/utils/styles/calcRem'
 
 export const StyledEloVoteContainer = styled('div')(({ theme }) => ({
   display: 'grid',
-  gridTemplateColumns: `repeat(2, minmax(${calcRem(80)}, 1fr))`,
-  gridTemplateRows: '100%',
+  gridTemplateColumns: '1fr',
   gridColumn: '1 / -1',
   gap: theme.metrics.md,
   inlineSize: '100%',
   maxInlineSize: calcRem(965),
-  maxBlockSize: '60vh',
   paddingInlineStart: calcRem(theme.metrics.sm),
   paddingInlineEnd: calcRem(theme.metrics.sm),
   marginInlineStart: 'auto',
   marginInlineEnd: 'auto',
 
   [breakpoint('md')]: {
+    gridTemplateColumns: `repeat(2, minmax(${calcRem(80)}, 1fr))`,
+    gridTemplateRows: '100%',
     gap: theme.metrics.lg,
+    maxBlockSize: '60vh',
   },
 }))
 


### PR DESCRIPTION
To address layout on mobile devices, stack them on top of each other. Reverts to side-by-side at tablet (768px) and up.

https://user-images.githubusercontent.com/9972287/165287556-f5fbfd15-00b5-4091-8c1e-ce16dcf26da4.mov



|Mobile|Tablet|
|---|---|
|<img width="358" alt="Screen Shot 2022-04-26 at 19 08 48" src="https://user-images.githubusercontent.com/9972287/165287672-120a54ad-44af-4aa8-8946-b9d2336ee776.png">|<img width="531" alt="Screen Shot 2022-04-26 at 19 11 36" src="https://user-images.githubusercontent.com/9972287/165287702-1205f731-e975-48ac-9eed-7c4821fe5c7b.png">|
