### PR TITLE
Hide ActionBar

### DIFF
--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 import { Template, TemplateProps } from './template'
 import { StyledMain } from './Layouts.styled'
 
-export const Main = ({ title, description, image, children, showHero }: TemplateProps): JSX.Element => (
-  <Template title={title} description={description} image={image} showHero={showHero}>
+export const Main = ({ title, description, image, children, showHero, showActionBar }: TemplateProps): JSX.Element => (
+  <Template title={title} description={description} image={image} showHero={showHero} showActionBar={showActionBar}>
     <StyledMain id="content">{children}</StyledMain>
   </Template>
 )

--- a/layouts/template.tsx
+++ b/layouts/template.tsx
@@ -17,9 +17,17 @@ export interface TemplateProps {
   image?: string
   showHero?: boolean
   children?: React.ReactNode
+  showActionBar?: boolean
 }
 
-export const Template = ({ children, title, description, image, showHero }: TemplateProps): JSX.Element => {
+export const Template = ({
+  children,
+  title,
+  description,
+  image,
+  showHero,
+  showActionBar = true,
+}: TemplateProps): JSX.Element => {
   const { conference, appConfig, dates } = useConfig()
   const menu = Menu(conference, dates)
 
@@ -31,7 +39,7 @@ export const Template = ({ children, title, description, image, showHero }: Temp
         <Header />
         <Nav menu={menu.Top} />
       </NavigationProvider>
-      <ActionBar />
+      {showActionBar && <ActionBar />}
       {showHero && <Hero />}
       {children}
       <Footer />

--- a/pages/vote/elo.tsx
+++ b/pages/vote/elo.tsx
@@ -84,7 +84,7 @@ export default function Elo({ sessions }: EloProps): JSX.Element {
   }
 
   return (
-    <Main title="Vote" description={`${conference.Name} voting page.`}>
+    <Main title="Vote" description={`${conference.Name} voting page.`} showActionBar={false}>
       <EloVote
         sessionA={sessionPair.SubmissionA}
         sessionB={sessionPair.SubmissionB}


### PR DESCRIPTION
### Problem

Feedback was to hide the ActionBar during the Elo voting process.

### Solution

Adds a new property that enables the ActionBar to be configured and
hides it on the Elo vote page.

### Reference

[Feedback thread](https://teams.microsoft.com/l/message/19:39b6e800540144018f685e906138d623@thread.skype/1651073618094?tenantId=f33985f0-9c96-4413-bda6-fb838481224b&groupId=e5193b22-958b-49a7-aaf1-d7c799ab041f&parentMessageId=1651073618094&teamName=Data%2C%20analytics%2C%20website%20and%20IT&channelName=General&createdTime=1651073618094)

### Test Plan

- [ ] View the Elo voting page `/vote/voting`
- [ ] The ActionBar shouldn't appear

### Device and Browser Testing

* Firefox