### PR TITLE
Elo title size adjustments

### DIFF
--- a/components/Voting/EloVote.styled.tsx
+++ b/components/Voting/EloVote.styled.tsx
@@ -47,10 +47,10 @@ export const StyledSessionTitle = styled('h3')(({ theme }) => ({
   display: '-webkit-box',
   marginBlockEnd: theme.metrics.md,
   color: '#333',
-  fontSize: calcRem(20),
-  lineHeight: 1.1,
+  fontSize: calcRem(18),
+  lineHeight: 1.2,
   fontWeight: theme.weights.bold,
-  WebkitLineClamp: 3,
+  WebkitLineClamp: 5,
   WebkitBoxOrient: 'vertical',
   overflow: 'hidden',
 }))


### PR DESCRIPTION
### Problem

Feedback from the team was that the Elo title shouldn't be clamped and
smaller.

### Solution

Reduces the font size, while slightly increase the line height for
breathing room. Doesn't completely remove the clamp but increases it to
5. If someone submits a talk title that long it's a problem.

### Reference

[Twist feedback thread](https://teams.microsoft.com/l/message/19:39b6e800540144018f685e906138d623@thread.skype/1651073618094?tenantId=f33985f0-9c96-4413-bda6-fb838481224b&groupId=e5193b22-958b-49a7-aaf1-d7c799ab041f&parentMessageId=1651073618094&teamName=Data%2C%20analytics%2C%20website%20and%20IT&channelName=General&createdTime=1651073618094)

### Test Plan

- [ ] View the Elo voting page `/vote/voting`
- [ ] The title font size should be smaller and not clamped (...)
- [ ] Unless it's really really long

### Device and Browser Testing

* Firefox