### PR TITLE
Elo Vote Tags

### DIFF
--- a/components/Voting/Elo.tsx
+++ b/components/Voting/Elo.tsx
@@ -7,6 +7,8 @@ import {
   StyledEloChoice,
   StyledSessionTitle,
   StyledSessionAbstract,
+  StyledEloTagList,
+  StyledEloTag,
 } from './EloVote.styled'
 
 type EloVoteProps = {
@@ -60,6 +62,13 @@ function EloChoice({ session, variant = 'primary', onChoice }: EloChoiceProps) {
   return (
     <StyledEloChoice variant={variant}>
       <StyledSessionTitle>{session.Title}</StyledSessionTitle>
+      {session.Tags.length > 0 ? (
+        <StyledEloTagList>
+          {session.Tags.map((tag) => (
+            <StyledEloTag key={tag}>{tag}</StyledEloTag>
+          ))}
+        </StyledEloTagList>
+      ) : null}
       <StyledSessionAbstract>
         {paragraphs.map((para) => (
           <Text key={para}>{para}</Text>

--- a/components/Voting/EloVote.styled.tsx
+++ b/components/Voting/EloVote.styled.tsx
@@ -88,3 +88,20 @@ export const StyledDrawButton = styled(Button)(({ theme }) => ({
   fontSize: theme.fonts.defaultSize,
   fontWeight: theme.weights.bold,
 }))
+
+export const StyledEloTagList = styled('ul')(({ theme }) => ({
+  display: 'flex',
+  flexWrap: 'wrap',
+  flexDirection: 'row',
+  gap: calcRem(theme.metrics.xs),
+  marginBlockEnd: calcRem(theme.metrics.md),
+}))
+
+export const StyledEloTag = styled('li')(({ theme }) => ({
+  padding: calcRem(theme.metrics.xs, theme.metrics.md),
+  fontSize: theme.fonts.sizeSm,
+  lineHeight: 1,
+  backgroundColor: theme.colors.inverse,
+  borderRadius: 9999,
+  color: theme.colors.white,
+}))

--- a/config/types.ts
+++ b/config/types.ts
@@ -230,7 +230,7 @@ export interface Session {
   Tags: string[]
 }
 
-export type EloSession = Pick<Session, 'Id' | 'Title' | 'Abstract'>
+export type EloSession = Pick<Session, 'Id' | 'Title' | 'Abstract' | 'Tags'>
 
 export interface Presenter {
   Id: string


### PR DESCRIPTION
### Problem

The committee would like the talk topics to appear on the voting to help inform voters

### Solution

Adds the talk tags to the EloChoice component to give voters more details
on what they're voting for.

### Reference

[Teams thread](https://teams.microsoft.com/l/message/19:39b6e800540144018f685e906138d623@thread.skype/1651073618094?tenantId=f33985f0-9c96-4413-bda6-fb838481224b&groupId=e5193b22-958b-49a7-aaf1-d7c799ab041f&parentMessageId=1651073618094&teamName=Data%2C%20analytics%2C%20website%20and%20IT&channelName=General&createdTime=1651073618094)

### Test Plan

- [ ] View the Elo Voting page `/vote/voting`
- [ ] The talks should now have tags appear underneath

![094fd9cf-fa5c-4de5-a362-3037b18dafcf](https://user-images.githubusercontent.com/1066856/165937725-e5e50fc7-1f7d-4e38-a18d-d35bac9e2bb7.jpg)

### Device and Browser Testing

* Firefox