### PR TITLE
Update OG Image

### DIFF
--- a/components/global/meta.tsx
+++ b/components/global/meta.tsx
@@ -20,7 +20,7 @@ declare global {
 const getTitle = (title: string, date: Date, name: string, showDate: boolean) =>
   `${title !== 'Home' ? title + ' - ' : ''}${name}${showDate ? ` | ${format(date, 'do MMMM yyyy')}` : ''}`
 
-export const Meta = ({ pageTitle, pageDescription, pageImage = '/static/images/logo-2021.png' }: MetaArgs) => {
+export const Meta = ({ pageTitle, pageDescription, pageImage = '/static/images/logo.png' }: MetaArgs) => {
   const { conference, appConfig, dates } = useConfig()
   const { pathname } = useRouter()
   const [title, setTitle] = React.useState('')


### PR DESCRIPTION
### Problem

The OG Image is showing the 2021 logo which is a weird experience for
users.

### Solution

Swap to the generic DDDPerth logo until such time as we have a more
suitable image available.

### Reference

[Teams thread](https://teams.microsoft.com/l/message/19:c7eda2cd204947dab4b83f87ef3d32f7@thread.skype/1651193290112?tenantId=f33985f0-9c96-4413-bda6-fb838481224b&groupId=6a3efafb-847d-4181-88bd-0e98d53b705b&parentMessageId=1651193290112&teamName=Conference%20Content&channelName=General&createdTime=1651193290112)

### Test Plan

- [ ] Run the dev server
- [ ] Check the OG Image meta data and see the image

### Device and Browser Testing

* Firefox