### PR TITLE
Ticket state

### DIFF
--- a/config/conference.ts
+++ b/config/conference.ts
@@ -15,7 +15,7 @@ const name = 'DDD Perth'
 const tagLine = `${name} is an inclusive non-profit conference for the Perth software community`
 
 const hideDate = false
-const ticketPurchasingOptions = TicketPurchasingOptions.WaitListOpen
+const ticketPurchasingOptions = TicketPurchasingOptions.OnSale
 const staticDate = '2022-09-10T08:00'
 const date = zonedTimeToUtc(staticDate, '+08:00')
 const endDate = add(date, { hours: 12 })

--- a/pages/tickets.tsx
+++ b/pages/tickets.tsx
@@ -1,4 +1,3 @@
-import Error from 'next/error'
 import React from 'react'
 import { NextPage, GetServerSideProps } from 'next'
 import { FaqList } from 'components/FAQList/FaqList'
@@ -15,10 +14,6 @@ import { getCommonServerSideProps } from 'components/utils/getCommonServerSidePr
 const TicketPage: NextPage = () => {
   const { conference, dates } = useConfig()
   const faqs = getFaqs(dates)
-
-  if (!dates.RegistrationOpen && conference.TicketPurchasingOptions !== TicketPurchasingOptions.WaitListOpen) {
-    return <Error statusCode={404} />
-  }
 
   return (
     <Main title="Tickets" description={`Purchase tickets for ${conference.Name}`}>


### PR DESCRIPTION
### Problem

The tickets were in a state that made the navigation and page available
when it shouldn't be yet.

### Solution

Changes the ticketPurchasingOptions to onSale which will hide the menu
as the RegistrationOpen remains false until the day.

### Reference

Was told about the issue in Fenders

### Test Plan

- [ ] You shouldn't be able to access `/tickets`
- [ ] There's no "Ticket" menu item

### Device and Browser Testing

* Firefox