### PR TITLE
User Defined layout

### DIFF
--- a/components/Voting/Elo.tsx
+++ b/components/Voting/Elo.tsx
@@ -8,15 +8,17 @@ import {
   StyledSessionAbstract,
   StyledEloTagList,
   StyledEloTag,
+  LayoutVariant,
 } from './EloVote.styled'
 
 type EloVoteProps = {
   sessionA: EloSession
   sessionB: EloSession
+  layout: LayoutVariant
   onSessionChoice: (winningSession: EloSession, losingSession: EloSession) => void
 }
 
-export function EloVote({ sessionA, sessionB, onSessionChoice }: EloVoteProps): JSX.Element {
+export function EloVote({ sessionA, sessionB, layout, onSessionChoice }: EloVoteProps): JSX.Element {
   function sessionChoiceHandler(session: EloSession['Id']) {
     const winner = session === sessionA.Id ? sessionA : sessionB
     const loser = session === sessionA.Id ? sessionB : sessionA
@@ -24,7 +26,7 @@ export function EloVote({ sessionA, sessionB, onSessionChoice }: EloVoteProps): 
   }
 
   return (
-    <StyledEloVoteContainer>
+    <StyledEloVoteContainer variant={layout}>
       <EloChoice
         key={sessionA.Id}
         session={sessionA}

--- a/components/Voting/EloVote.styled.tsx
+++ b/components/Voting/EloVote.styled.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import { Button } from 'components/global/Button/Button'
+import { srOnly } from 'components/utils/styles/accessibility'
 import { breakpoint, breakpointMax } from 'components/utils/styles/breakpoints'
 import { calcRem } from 'components/utils/styles/calcRem'
 
@@ -138,9 +139,7 @@ export const StyledLayoutLabel = styled('label')(({ theme }) => ({
   marginBlockStart: calcRem(theme.metrics.sm),
   textAlign: 'center',
 
-  input: {
-    display: 'none',
-  },
+  input: srOnly,
 
   span: {
     color: theme.colors.dddpink,

--- a/components/Voting/EloVote.styled.tsx
+++ b/components/Voting/EloVote.styled.tsx
@@ -1,30 +1,38 @@
 import styled from '@emotion/styled'
 import { Button } from 'components/global/Button/Button'
-import { breakpoint } from 'components/utils/styles/breakpoints'
+import { breakpoint, breakpointMax } from 'components/utils/styles/breakpoints'
 import { calcRem } from 'components/utils/styles/calcRem'
 
-export const StyledEloVoteContainer = styled('div')(({ theme }) => ({
-  display: 'grid',
-  gridTemplateColumns: `repeat(1, minmax(${calcRem(80)}, 1fr))`,
-  gridColumn: '1 / -1',
-  gap: theme.metrics.md,
-  inlineSize: '100%',
-  maxInlineSize: calcRem(965),
-  paddingInlineStart: calcRem(theme.metrics.sm),
-  paddingInlineEnd: calcRem(theme.metrics.sm),
-  marginInlineStart: 'auto',
-  marginInlineEnd: 'auto',
-  overflowY: 'auto',
-  maxBlockSize: '65vh',
+export type LayoutVariant = 'stacked' | 'expanded'
 
-  [breakpoint('md')]: {
-    gap: theme.metrics.lg,
-  },
-  [breakpoint('sm')]: {
-    gridTemplateColumns: `repeat(2, minmax(${calcRem(80)}, 1fr))`,
-    maxBlockSize: 'none',
-  },
-}))
+type StyledEloVoteContainerProps = {
+  variant: LayoutVariant
+}
+
+export const StyledEloVoteContainer = styled('div')<StyledEloVoteContainerProps>(
+  ({ theme }) => ({
+    gridColumn: '1 / -1',
+    display: 'grid',
+    gap: theme.metrics.md,
+    gridTemplateColumns: 'repeat(2, 1fr)',
+    gridTemplateRows: 'minmax(0, 1fr)',
+    maxInlineSize: calcRem(965),
+    paddingInlineStart: calcRem(theme.metrics.sm),
+    paddingInlineEnd: calcRem(theme.metrics.sm),
+    marginInlineStart: 'auto',
+    marginInlineEnd: 'auto',
+    maxBlockSize: '65vh',
+  }),
+  ({ variant }) => ({
+    [breakpointMax('md')]: {
+      blockSize: '100%',
+      maxBlockSize: variant === 'stacked' ? '75vh' : undefined,
+      gridTemplateColumns: 'unset',
+      gridTemplateRows: variant === 'stacked' ? 'repeat(2, minmax(0, 1fr))' : 'auto',
+      overflowY: 'auto',
+    },
+  }),
+)
 
 type StyledEloChoiceProps = {
   variant?: 'primary' | 'secondary'
@@ -33,7 +41,7 @@ type StyledEloChoiceProps = {
 export const StyledEloChoice = styled('div')<StyledEloChoiceProps>(({ theme, variant = 'primary' }) => ({
   display: 'flex',
   flexDirection: 'column',
-  padding: calcRem(theme.metrics.lg),
+  padding: calcRem(theme.metrics.md),
   paddingInlineStart: calcRem(12),
   paddingInlineEnd: calcRem(12),
   backgroundColor: 'rgba(86, 88, 91, 0.1)',
@@ -59,9 +67,8 @@ export const StyledSessionTitle = styled('h3')(({ theme }) => ({
   overflow: 'hidden',
 }))
 
-export const StyledSessionAbstract = styled('div')(({ theme }) => ({
+export const StyledSessionAbstract = styled('div')(() => ({
   flex: 1,
-  marginBlockEnd: calcRem(theme.metrics.md),
   overflow: 'hidden',
   overflowY: 'auto',
 }))
@@ -120,4 +127,27 @@ export const StyledEloTag = styled('li')(({ theme }) => ({
   backgroundColor: theme.colors.inverse,
   borderRadius: 9999,
   color: theme.colors.white,
+}))
+
+export const StyledEloVoteFooter = styled('div')(() => ({
+  textAlign: 'center',
+}))
+
+export const StyledLayoutLabel = styled('label')(({ theme }) => ({
+  display: 'block',
+  marginBlockStart: calcRem(theme.metrics.sm),
+  textAlign: 'center',
+
+  input: {
+    display: 'none',
+  },
+
+  span: {
+    color: theme.colors.dddpink,
+    textDecoration: 'underline',
+  },
+
+  [breakpoint('md')]: {
+    display: 'none',
+  },
 }))

--- a/pages/vote/elo.tsx
+++ b/pages/vote/elo.tsx
@@ -55,7 +55,6 @@ async function postPair(winningSessionId: string, losingSessionId: string, isDra
       headers,
       body: JSON.stringify(body),
     })
-    logEvent('voting', 'elo', { sessionId: body.VoterSessionId })
   } catch (e) {
     logException('Error submitting vote', e, { sessionId: body.VoterSessionId })
   }
@@ -92,6 +91,8 @@ export default function Elo({ sessions, userDefinedLayout = 'stacked' }: EloProp
       variant: layoutVariant,
       winningVote: winningSession.Id,
       losingSession: losingSession.Id,
+      sessionA: sessionPair.SubmissionA.Id,
+      sessionB: sessionPair.SubmissionB.Id,
       isDraw,
     })
 


### PR DESCRIPTION
### Problem

See Teams

### Solution

Allows the user to define their desired mobile layout based on a stacked
and expanded view.

Triggers an App Insights event when the layout is changed and on voting.
Their desired layout is also stored as a cookie in case they return at
a later point to continue voting.

### Reference

[Ben's layout suggestion](https://teams.microsoft.com/l/message/19:b5da72942fd243c1a12096bf8c3c7f86@thread.skype/1652935378854?tenantId=f33985f0-9c96-4413-bda6-fb838481224b&groupId=e5193b22-958b-49a7-aaf1-d7c799ab041f&parentMessageId=1652191090723&teamName=Data%2C%20analytics%2C%20website%20and%20IT&channelName=Elo%20Voting&createdTime=1652935378854)

### Test Plan

**Layout**

- [ ] View the elo voting page
- [ ] The layout will be stacked by default
- [ ] Toggle to the expanded layout and it will expand

**Stored layout**

- [ ] View the page at mobile resolution
- [ ] Change the layout
- [ ] Refresh the page
- [ ] The last layout will persist

**App Insights**

Note: these can take a little time to appear

**Layout**
- [ ] Open the network panel and clear everything
- [ ] Toggle the layout
- [ ] Wait
- [ ] A dc.services.visualstudiocode request should appear
- [ ] The data will match your current layout

**Vote**

- [ ] Cast a vote
- [ ] Wait
- [ ] A dc.services.visualstudiocode request should appear
- [ ] The data will match your vote

### Device and Browser Testing

* Firefox