### PR TITLE
Fix formatting of abstract when there is extra space in certain places

### DIFF
--- a/components/Voting/Elo.tsx
+++ b/components/Voting/Elo.tsx
@@ -1,6 +1,4 @@
-import { Text } from 'components/global/text'
 import { EloSession } from 'config/types'
-import { useMemo } from 'react'
 import {
   StyledEloVoteContainer,
   StyledEloChoice,
@@ -9,6 +7,7 @@ import {
   StyledEloTagList,
   StyledEloTag,
   LayoutVariant,
+  StyledAbstractText,
 } from './EloVote.styled'
 
 type EloVoteProps = {
@@ -53,16 +52,6 @@ type EloChoiceProps = {
 }
 
 function EloChoice({ session, variant = 'primary' }: EloChoiceProps) {
-  const abstract = session.Abstract
-  const paragraphs = useMemo(
-    () =>
-      abstract
-        .split('\n')
-        .map((para) => para.trim())
-        .filter((para) => para.length > 0),
-    [abstract],
-  )
-
   return (
     <StyledEloChoice variant={variant}>
       <StyledSessionTitle>
@@ -76,9 +65,7 @@ function EloChoice({ session, variant = 'primary' }: EloChoiceProps) {
         </StyledEloTagList>
       ) : null}
       <StyledSessionAbstract>
-        {paragraphs.map((para) => (
-          <Text key={para}>{para}</Text>
-        ))}
+        <StyledAbstractText tag="div">{session.Abstract}</StyledAbstractText>
       </StyledSessionAbstract>
     </StyledEloChoice>
   )

--- a/components/Voting/Elo.tsx
+++ b/components/Voting/Elo.tsx
@@ -54,7 +54,14 @@ type EloChoiceProps = {
 
 function EloChoice({ session, variant = 'primary' }: EloChoiceProps) {
   const abstract = session.Abstract
-  const paragraphs = useMemo(() => abstract.split('\n').filter((para) => !!para), [abstract])
+  const paragraphs = useMemo(
+    () =>
+      abstract
+        .split('\n')
+        .map((para) => para.trim())
+        .filter((para) => para.length > 0),
+    [abstract],
+  )
 
   return (
     <StyledEloChoice variant={variant}>

--- a/components/Voting/EloVote.styled.tsx
+++ b/components/Voting/EloVote.styled.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import { Button } from 'components/global/Button/Button'
+import { Text } from 'components/global/text'
 import { srOnly } from 'components/utils/styles/accessibility'
 import { breakpoint, breakpointMax } from 'components/utils/styles/breakpoints'
 import { calcRem } from 'components/utils/styles/calcRem'
@@ -72,6 +73,10 @@ export const StyledSessionAbstract = styled('div')(() => ({
   flex: 1,
   overflow: 'hidden',
   overflowY: 'auto',
+}))
+
+export const StyledAbstractText = styled(Text)(() => ({
+  whiteSpace: 'pre-wrap',
 }))
 
 type StyledVoteButtonProps = {


### PR DESCRIPTION
I've got two commits here:
- The first just strips out empty paragraphs after we split on `\n`, but that results in extra margin between dot points.
- The second means we preserve whitespace from the text, but comes at the expense of a bit of semantic HTML. Specifically, the text is in a single `div` (we could have used `p`, but I thought having a single `p` tag with multiple paragraphs in it may have been worse than many paragraphs in a single `div`).

|With empty paragraphs removed|With `white-space: pre-wrap`|
|---|---|
|![image](https://user-images.githubusercontent.com/9972287/169824907-6e13e388-b922-4591-aea1-65ffc0a28c6f.png)|![image](https://user-images.githubusercontent.com/9972287/169825340-9887113b-5482-4b91-a8fd-cafc6eafabca.png)|
