### PR TITLE
Include/set session id cookie in GET /EloVotingGetPair

### DIFF
--- a/pages/vote/elo.tsx
+++ b/pages/vote/elo.tsx
@@ -30,7 +30,9 @@ type EloProps = {
 }
 
 async function fetchPair() {
-  const resp = await fetch(process.env.NEXT_PUBLIC_ELO_PAIR)
+  const resp = await fetch(process.env.NEXT_PUBLIC_ELO_PAIR, {
+    credentials: 'include',
+  })
   const data = await resp.json()
 
   return data


### PR DESCRIPTION
> **Warning**
> Can't go in before a corresponding back-end change to CORS rules

The changes to track a list of sessions per-user by cookie means that we need to include credentials (i.e. cookies) in the `fetch` request.

Unfortunately, browsers don't like you including cookies in a CORS request where `Access-Control-Allow-Origin` is a wildcard `*`, so this will need a change first.

![image](https://user-images.githubusercontent.com/9972287/171134651-b0d67904-ac9a-4165-8bb2-b90bd5db8724.png)
https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSNotSupportingCredentials

