### PR TITLE
Include X-DDDPerth-VotingSessionId header in GET elo pair

### DIFF
--- a/components/Voting/VoteConst.ts
+++ b/components/Voting/VoteConst.ts
@@ -1,1 +1,2 @@
 export const PRIVACY_ACCEPTED = 'vote-privacy-check'
+export const ELO_VOTING_SESSION_ID = 'ddd-elo-voting-session-id'


### PR DESCRIPTION
Backend was changed from accepting a cookie to a header -- we were having problems getting the cookie version to work because of CORS and SameSite cookies, etc.

Header is easy, too, so we've switched. 

See https://github.com/dddwa/ddd-backend/pull/81 and https://github.com/dddwa/ddd-backend/pull/83 for context