### PR TITLE
Restrict height of width of images/svg when we get a flash of unstyled content

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,6 +6,17 @@ export default class MyDocument extends Document {
       <Html lang="en-AU">
         <Head>
           <link href="https://fonts.googleapis.com/css?family=Hind:400,500,700&display=swap" rel="stylesheet" />
+          <style>
+            {`
+svg {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+img {
+  max-width: 150px;
+  height: auto;
+}`}
+          </style>
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
This is a first-pass at improving the appearance when we get a flash of unstyled content (FOUC)

Obviously it's better to fix the FOUC, but we can start with this.

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/9972287/171409454-9cd47654-a9ec-4c35-95ac-43542cabd8e3.png)|![image](https://user-images.githubusercontent.com/9972287/171409462-ad6547ad-eeeb-4db1-8e9a-5f9145b47108.png)|

To test for yourself, disable javascript in your dev tools and refresh the page