### PR TITLE
Remove flash of unstyled content

### DIFF
--- a/components/global/meta.tsx
+++ b/components/global/meta.tsx
@@ -25,16 +25,16 @@ const getTitle = (title: string, date: Date, name: string, showDate: boolean) =>
 export const Meta = ({ pageTitle, pageDescription, pageImage }: MetaArgs) => {
   const { conference, appConfig, dates } = useConfig()
   const { pathname } = useRouter()
-  const [title, setTitle] = React.useState('')
   const conferenceDates = getConferenceDates(conference, dateTimeProvider.now())
   const ogImage =
     pageImage || conference.Instance !== '2022' || conferenceDates.IsComplete
       ? '/static/images/logo.png'
       : '/static/images/logo-2022-og.jpg'
 
-  React.useEffect(() => {
-    setTitle(getTitle(pageTitle, conference.Date, conference.Name, !conference.HideDate && !dates.IsComplete))
-  }, [pageTitle, dates.IsComplete, conference.HideDate, conference.Name, conference.Date])
+  const title = React.useMemo(
+    () => getTitle(pageTitle, conference.Date, conference.Name, !conference.HideDate && !dates.IsComplete),
+    [pageTitle, dates.IsComplete, conference.HideDate, conference.Name, conference.Date],
+  )
 
   React.useEffect(() => {
     if (!window.GA_INITIALIZED) {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { CacheProvider, Global, ThemeProvider } from '@emotion/react'
-import createCache from '@emotion/cache'
+import { Global, ThemeProvider } from '@emotion/react'
 import { theme } from 'components/utils/styles/theme'
 import { CSSReset } from 'components/utils/styles/reset'
 import { globalCSS } from 'components/utils/styles/global'
@@ -9,20 +8,13 @@ import { AppProps } from 'next/app'
 import Script from 'next/script'
 
 function CustomApp({ Component, pageProps }: AppProps): JSX.Element {
-  const emotionCache = createCache({
-    key: 'emotion-cache',
-  })
-  emotionCache.compat = true
-
   return (
     <ConfigProvider>
-      <CacheProvider value={emotionCache}>
-        <ThemeProvider theme={theme}>
-          <Global styles={CSSReset} />
-          <Global styles={globalCSS} />
-          <Component {...pageProps} />
-        </ThemeProvider>
-      </CacheProvider>
+      <ThemeProvider theme={theme}>
+        <Global styles={CSSReset} />
+        <Global styles={globalCSS} />
+        <Component {...pageProps} />
+      </ThemeProvider>
       {process.env.NEXT_PUBLIC_APPINSIGHTS_INSTRUMENTATIONKEY ? (
         <Script
           id="appInsightsScript"

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,17 +6,6 @@ export default class MyDocument extends Document {
       <Html lang="en-AU">
         <Head>
           <link href="https://fonts.googleapis.com/css?family=Hind:400,500,700&display=swap" rel="stylesheet" />
-          <style>
-            {`
-svg {
-  width: 1.5rem;
-  height: 1.5rem;
-}
-img {
-  max-width: 150px;
-  height: auto;
-}`}
-          </style>
         </Head>
         <body>
           <Main />

--- a/test/test-util.tsx
+++ b/test/test-util.tsx
@@ -1,22 +1,14 @@
 import React from 'react'
 import { render as rtlRender, RenderResult } from '@testing-library/react'
-import { CacheProvider, ThemeProvider } from '@emotion/react'
-import createCache from '@emotion/cache'
+import { ThemeProvider } from '@emotion/react'
 import { theme } from 'components/utils/styles/theme'
 import { ConfigProvider } from 'Context/Config'
 
 function render(ui: React.ReactElement, { ...options } = {}): RenderResult {
-  const emotionCache = createCache({
-    key: 'test-cache',
-  })
-  emotionCache.compat = true
-
   function Wrapper({ children }) {
     return (
       <ConfigProvider>
-        <CacheProvider value={emotionCache}>
-          <ThemeProvider theme={theme}>{children}</ThemeProvider>
-        </CacheProvider>
+        <ThemeProvider theme={theme}>{children}</ThemeProvider>
       </ConfigProvider>
     )
   }


### PR DESCRIPTION
Noticed a flash of unstyled content. I had another PR to adjust what appeared there because I thought figuring it out could be tricky, but it turns out it wasn't that bad.

https://emotion.sh/docs/ssr#nextjs suggested it "works out of the box" with Emotion 11, and https://github.com/vercel/next.js/tree/canary/examples/with-emotion didn't have any reference to the CacheProvider, so I tried removing it and disabling JS and the flash of unstyled content (FOUC) was gone