### PR TITLE
Add votingSessionId from header into app insights event for voting:vote

### DIFF
--- a/pages/vote/elo.tsx
+++ b/pages/vote/elo.tsx
@@ -105,6 +105,7 @@ export default function Elo({ sessions, votingSessionId, userDefinedLayout = 'st
       sessionA: sessionPair.SubmissionA.Id,
       sessionB: sessionPair.SubmissionB.Id,
       isDraw,
+      votingSessionId,
     })
 
     if (typeof nextPair !== 'undefined') {


### PR DESCRIPTION
Add the sessionId from the header into the appinsights event so that we can track it better

There is an App Insights session ID but this isn't that one :/ Bit awkward, but we fetch the first pair on the server and we don't have the app insights one there, so we can't use the same one