### PR TITLE
Remove @types/react-ga that might be causing build issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "@types/node": "^17.0.21",
         "@types/react": "17.0.40",
         "@types/react-beautiful-dnd": "^13.1.2",
-        "@types/react-ga": "^2.3.0",
         "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.14.0",
         "@typescript-eslint/parser": "^5.14.0",
@@ -1903,16 +1902,6 @@
       "dev": true,
       "dependencies": {
         "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-ga": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@types/react-ga/-/react-ga-2.3.0.tgz",
-      "integrity": "sha512-7Vkv6wH1Kem4vkjuJxRYxDgLfokm0shugDk0W5p9C28POrsPAXezLbgP5C2tyFZ7lKARdyrCxwkdRTC1UV0dHg==",
-      "deprecated": "This is a stub types definition for react-ga (https://github.com/react-ga/react-ga). react-ga provides its own type definitions, so you don't need @types/react-ga installed!",
-      "dev": true,
-      "dependencies": {
-        "react-ga": "*"
       }
     },
     "node_modules/@types/react-redux": {
@@ -10930,15 +10919,6 @@
       "dev": true,
       "requires": {
         "@types/react": "*"
-      }
-    },
-    "@types/react-ga": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@types/react-ga/-/react-ga-2.3.0.tgz",
-      "integrity": "sha512-7Vkv6wH1Kem4vkjuJxRYxDgLfokm0shugDk0W5p9C28POrsPAXezLbgP5C2tyFZ7lKARdyrCxwkdRTC1UV0dHg==",
-      "dev": true,
-      "requires": {
-        "react-ga": "*"
       }
     },
     "@types/react-redux": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@types/node": "^17.0.21",
     "@types/react": "17.0.40",
     "@types/react-beautiful-dnd": "^13.1.2",
-    "@types/react-ga": "^2.3.0",
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.14.0",
     "@typescript-eslint/parser": "^5.14.0",


### PR DESCRIPTION
We get a build error due to mismatched peer dependencies related to `react-ga` and `@types/react-ga`

![Mismatched peer dependency error](https://user-images.githubusercontent.com/9972287/172990785-571653af-ebe9-4d17-8f96-82801865b6b7.png)

There was also a warning when you install that `react-ga` is no longer required.

```
npm WARN deprecated @types/react-ga@2.3.0: This is a stub types definition for react-ga (https://github.com/react-ga/react-ga). react-ga provides its own type definitions, so you don't need @types/react-ga installed!
```

I figure removing the redundant types might help with the mismatched peer deps.

[Teams chat](https://teams.microsoft.com/l/message/19:39b6e800540144018f685e906138d623@thread.skype/1654824120129?tenantId=f33985f0-9c96-4413-bda6-fb838481224b&groupId=e5193b22-958b-49a7-aaf1-d7c799ab041f&parentMessageId=1654824120129&teamName=Data%2C%20analytics%2C%20website%20and%20IT&channelName=General&createdTime=1654824120129)