### PR TITLE
Prevent scrolling to top when you close a session

### DIFF
--- a/components/Agenda/Agenda.tsx
+++ b/components/Agenda/Agenda.tsx
@@ -80,7 +80,8 @@ export const Agenda = ({ sessions, ...props }: AgendaProps) => {
   }
 
   const onDismissHandler = () => {
-    Router.replace(`${Router.pathname}`)
+    const url = `${Router.pathname}`
+    Router.replace(url, url, { shallow: true, scroll: false })
     dispatch({ type: 'dismiss' })
   }
 


### PR DESCRIPTION
When you open a session by clicking on in in the agenda, and then dismiss, the page scrolls back to the top. This is a bit annoying when you want to look at a brand new agenda

By tweaking the routing events in Next.js, we can:
- prevent it from scrolling back to the top with `scroll: false`
- prevent it from re-fetching data (and spamming the agenda endpoint unnecessarily) with `shallow: true`