### PR TITLE
Update agenda session modal to be able to show link to livestream if such a URL is available

### DIFF
--- a/components/Agenda/Agenda.tsx
+++ b/components/Agenda/Agenda.tsx
@@ -6,7 +6,7 @@ import { SessionGroup, useSessionGroups } from 'components/utils/useSessionGroup
 import { StyledCenteredParagraph, StyledSponsorLogo } from 'components/Agenda/Agenda.styled'
 import { SessionDetails } from 'components/Agenda/SessionDetails'
 import { StyledCloseButton, StyledDialogContent, StyledDialogOverlay } from 'components/Agenda/SessionDetails.styled'
-export type onSelectCallback = (session: Session, sponsor: Sponsor) => void
+export type onSelectCallback = (session: Session, sponsor: Sponsor, livestream: string) => void
 
 interface AgendaProps {
   sessions: Session[]
@@ -22,6 +22,7 @@ interface AgendaActionSelect {
   type: 'selected'
   session: Session
   sponsor?: Sponsor
+  livestream?: string
 }
 
 interface AgendaActionDismiss {
@@ -34,6 +35,7 @@ interface AgendaState {
   showModal: boolean
   selectedSession?: Session
   sessionSponsor?: Sponsor
+  sessionLivestream?: string
 }
 
 function agendaReducer(state: AgendaState, action: AllAgendaActions): AgendaState {
@@ -42,6 +44,7 @@ function agendaReducer(state: AgendaState, action: AllAgendaActions): AgendaStat
       return {
         selectedSession: action.session,
         sessionSponsor: action.sponsor,
+        sessionLivestream: action.livestream,
         showModal: true,
       }
     case 'dismiss':
@@ -73,10 +76,10 @@ export const Agenda = ({ sessions, ...props }: AgendaProps) => {
     }
   }, [sessions, props.selectedSessionId])
 
-  const onSelectHandler = (session: Session, sponsor: Sponsor) => {
+  const onSelectHandler = (session: Session, sponsor: Sponsor, livestream: string) => {
     const url = `${Router.pathname}?sessionId=${session.Id}`
     Router.push(url, url, { shallow: true })
-    dispatch({ type: 'selected', session, sponsor })
+    dispatch({ type: 'selected', session, sponsor, livestream })
   }
 
   const onDismissHandler = () => {
@@ -104,6 +107,7 @@ export const Agenda = ({ sessions, ...props }: AgendaProps) => {
             showBio={true}
             hideTags={props.hideTags}
             hideLevelAndFormat={props.hideLevel}
+            livestream={sessionState.sessionLivestream}
           />
 
           {props.acceptingFeedback && (

--- a/components/Agenda/AgendaContext.tsx
+++ b/components/Agenda/AgendaContext.tsx
@@ -17,7 +17,7 @@ interface AgendaProviderProps
   sessions: Session[]
   sponsors: Sponsor[]
   rooms: string[]
-  livestreams: string[]
+  livestreams?: string[]
 }
 
 const AgendaContext = React.createContext<AgendaContextProps | undefined>(undefined)

--- a/components/Agenda/AgendaContext.tsx
+++ b/components/Agenda/AgendaContext.tsx
@@ -7,6 +7,7 @@ interface AgendaContextProps {
   getSession: (id: string) => Session
   getSponsor: (id: string) => Sponsor
   getRoom: (roomId: number | string) => string
+  getLivestream: (roomId: number | string) => string
 }
 
 interface AgendaProviderProps
@@ -16,6 +17,7 @@ interface AgendaProviderProps
   sessions: Session[]
   sponsors: Sponsor[]
   rooms: string[]
+  livestreams: string[]
 }
 
 const AgendaContext = React.createContext<AgendaContextProps | undefined>(undefined)
@@ -25,10 +27,12 @@ export const AgendaProvider = ({
   sessions,
   sponsors,
   rooms,
+  livestreams,
   onSelect,
   getRoom = (roomId) => (typeof roomId === 'string' ? roomId : rooms[roomId]),
   getSession = (id) => sessions.find((session) => session.Id === id),
   getSponsor = (id) => sponsors.find((sponsor) => sponsor.id === id),
+  getLivestream = (roomId) => (typeof roomId === 'number' ? livestreams[roomId] : ''),
 }: AgendaProviderProps) => {
   return (
     <AgendaContext.Provider
@@ -37,6 +41,7 @@ export const AgendaProvider = ({
         getSession,
         getSponsor,
         onSelect,
+        getLivestream,
       }}
     >
       {children}

--- a/components/Agenda/AgendaSession.tsx
+++ b/components/Agenda/AgendaSession.tsx
@@ -32,7 +32,7 @@ export const AgendaSession = ({
   renderTitle,
   renderPresenters,
 }: AgendaSessionProps) => {
-  const { onSelect, getSession, getSponsor, getRoom } = useAgendaContext()
+  const { onSelect, getSession, getSponsor, getRoom, getLivestream } = useAgendaContext()
   const session = sessionId ? getSession(sessionId) : false
   const sponsor = sponsorId ? getSponsor(sponsorId) : undefined
   const presenters = session ? session.Presenters.map((p) => p.Name).join(', ') : ''
@@ -41,7 +41,11 @@ export const AgendaSession = ({
     <StyledSection fullWidth={fullWidth} session={session !== false}>
       {!session && !children && <StyledAgendaPresenter>Loading&hellip;</StyledAgendaPresenter>}
       {session && (
-        <StyledAgendaButton type="button" isKeynote={isKeynote} onClick={() => onSelect(session, sponsor)}>
+        <StyledAgendaButton
+          type="button"
+          isKeynote={isKeynote}
+          onClick={() => onSelect(session, sponsor, getLivestream(room))}
+        >
           {renderPresenters ? (
             renderPresenters(presenters)
           ) : (

--- a/components/Agenda/SessionDetails.styled.tsx
+++ b/components/Agenda/SessionDetails.styled.tsx
@@ -62,7 +62,7 @@ export const StyledBioFigure = styled('figure')({
   display: 'flex',
   flexWrap: 'wrap',
   alignItems: 'center',
-  marginBottom: calcRem(30),
+  marginBottom: calcRem(15),
 })
 StyledBioFigure.displayName = 'StyledBioFigure'
 
@@ -157,3 +157,14 @@ export const StyledTagList = styled('ul')({
   },
 })
 StyledTagList.displayName = 'StyledTagList'
+
+export const StyledLivestreamLink = styled('div')(({ theme }) => ({
+  marginBottom: calcRem(15),
+  svg: {
+    width: calcRem(theme.metrics.xl),
+    marginRight: calcRem(theme.metrics.sm),
+    fill: 'red',
+    position: 'relative',
+    top: calcRem(5),
+  },
+}))

--- a/components/Agenda/SessionDetails.tsx
+++ b/components/Agenda/SessionDetails.tsx
@@ -12,6 +12,8 @@ import {
   StyledSpeakerBioHeader,
   StyledTagList,
 } from './SessionDetails.styled'
+import { YouTubeIcon } from 'components/global/Icons/Youtube'
+import { StyledLivestreamLink } from './SessionDetails.styled'
 
 interface SessionDetailsProps {
   session: Session
@@ -19,6 +21,7 @@ interface SessionDetailsProps {
   hideTags: boolean
   hideLevelAndFormat: boolean
   showBio: boolean
+  livestream: string
 }
 
 export const SessionDetails = ({
@@ -27,6 +30,7 @@ export const SessionDetails = ({
   hideTags = false,
   hideLevelAndFormat = false,
   showBio,
+  livestream,
 }: SessionDetailsProps) => {
   return (
     <Fragment>
@@ -68,6 +72,14 @@ export const SessionDetails = ({
             )}
           </StyledBioFigure>
         ))}
+      {livestream && (
+        <StyledLivestreamLink>
+          <SafeLink href={livestream} target="_blank">
+            <YouTubeIcon />
+            Watch Livestream
+          </SafeLink>
+        </StyledLivestreamLink>
+      )}
       <StyledPreWrappedParagraph>{session.Abstract}</StyledPreWrappedParagraph>
 
       {(!hideLevelAndFormat || !hideTags) && (

--- a/components/currentAgenda.tsx
+++ b/components/currentAgenda.tsx
@@ -64,6 +64,7 @@ export const CurrentAgenda = ({
               sessions={agendaSessions}
               sponsors={sponsors}
               rooms={Conference.RoomNames}
+              livestreams={Conference.Livestreams}
             >
               {Conference.ShowNextSessions && nextSessionGroup && nextSessionGroup.sessions.length > 0 && (
                 <StyledUpNext>

--- a/config/conference.ts
+++ b/config/conference.ts
@@ -204,6 +204,18 @@ const Conference: IConference = {
     'Maali (Black Swan)',
   ],
 
+  Livestreams: [
+    'https://youtu.be/ovEA5PaOdWo?list=PLkLJSte3oodSYGOtIq-4ntOD5CH8b-lkx',
+    'https://youtu.be/8mq3bCMrmbE?list=PLkLJSte3oodSYGOtIq-4ntOD5CH8b-lkx',
+    'https://youtu.be/DsFlSkTPH-Y?list=PLkLJSte3oodSYGOtIq-4ntOD5CH8b-lkx',
+    'https://youtu.be/pqRQ4rN6adg?list=PLkLJSte3oodSYGOtIq-4ntOD5CH8b-lkx',
+    'https://youtu.be/ox6ixHfs4xM?list=PLkLJSte3oodSYGOtIq-4ntOD5CH8b-lkx',
+    'https://youtu.be/2KjEBFAVgoU?list=PLkLJSte3oodSYGOtIq-4ntOD5CH8b-lkx',
+    'https://youtu.be/Plo8dSxAjHw?list=PLkLJSte3oodSYGOtIq-4ntOD5CH8b-lkx',
+    'https://youtu.be/EU-VeLYi8LM?list=PLkLJSte3oodSYGOtIq-4ntOD5CH8b-lkx',
+    'https://youtu.be/LQ5vtriC_bI?list=PLkLJSte3oodSYGOtIq-4ntOD5CH8b-lkx',
+  ],
+
   SessionGroups: [
     {
       sessions: ['337380'],

--- a/config/types.ts
+++ b/config/types.ts
@@ -82,6 +82,7 @@ export interface Conference {
   Keynotes: Session[]
 
   RoomNames: string[]
+  Livestreams: string[]
 
   SessionGroups: SessionGroupWithIds[]
 


### PR DESCRIPTION
This change defines a new Conference.Livestreams configurable list, which is expected to provide one URL per livestream for a given room. The implementation is a bit brittle in the sense that it relies on the list of livestreams to follow the exact same order as the list of rooms - if rooms get re-ordered, the matching stream URLs would also need to be adjusted. (But this indexing is also the basis for how the current agenda page currently works, so we're just extending the convention)

When the user selects an agenda item from the grid, the corresponding livestream is looked up, using the room ID as a proxy. The modal checks for a livestream URL being passed in and makes the 'Watch Livestream' link visible. (If no URL is passed in, that element remains hidden) There is currently a limitation in that the modal can only show the link if opened via user interaction from the agenda. If navigating directly to a given session (via /agenda?sessionId=X), no livestream URL is picked up, thus the link doesn't get rendered. I'd suggest this is OK for now, as I think it would require a bit of rewiring to map Session instances to rooms/livestreams properly.

Desktop example:
![image](https://user-images.githubusercontent.com/818666/188310881-3627bfe9-fdfd-4999-bf15-daa75c56d1d7.png)

Mobile example:
![image](https://user-images.githubusercontent.com/818666/188310898-f16f51d4-4b33-442d-be49-d629e906f755.png)
