### PR TITLE
Fix multi-talk slot in "up next" section

### DIFF
--- a/components/TestingControl/TestingControl.tsx
+++ b/components/TestingControl/TestingControl.tsx
@@ -66,7 +66,7 @@ export const TestingControl = (): JSX.Element => {
           <StyledButton kind="primary" onClick={() => storeTime(conference.Date)}>
             On the day
           </StyledButton>
-          <StyledButton kind="primary" onClick={() => storeTime(set(conference.Date, { hours: 11, minutes: 0 }))}>
+          <StyledButton kind="primary" onClick={() => storeTime(set(conference.Date, { hours: 15, minutes: 0 }))}>
             During the day
           </StyledButton>
           <StyledButton kind="primary" onClick={() => storeTime(conference.EndDate)}>

--- a/components/currentAgenda.tsx
+++ b/components/currentAgenda.tsx
@@ -71,15 +71,29 @@ export const CurrentAgenda = ({
                   <h2>Up next</h2>
                   <StyledAgendaRow>
                     <AgendaTime time={nextSessionGroup.timeStart} />
-                    {nextSessionGroup.sessions.map((session, index) => (
-                      <AgendaSession
-                        key={session.Id}
-                        sessionId={session.ExternalId}
-                        fullWidth={nextSessionGroup.sessions.length === 1}
-                        room={index}
-                        alwaysShowRoom={true}
-                      />
-                    ))}
+                    {nextSessionGroup.sessions.map((session, index) =>
+                      Array.isArray(session) ? (
+                        <Fragment key={index}>
+                          {session.map((sess) => (
+                            <AgendaSession
+                              key={sess.Id}
+                              sessionId={sess.ExternalId}
+                              fullWidth={nextSessionGroup.sessions.length === 1}
+                              room={index}
+                              alwaysShowRoom={true}
+                            />
+                          ))}
+                        </Fragment>
+                      ) : (
+                        <AgendaSession
+                          key={session.Id}
+                          sessionId={session.ExternalId}
+                          fullWidth={nextSessionGroup.sessions.length === 1}
+                          room={index}
+                          alwaysShowRoom={true}
+                        />
+                      ),
+                    )}
                   </StyledAgendaRow>
                 </StyledUpNext>
               )}

--- a/components/utils/useSessionGroups.ts
+++ b/components/utils/useSessionGroups.ts
@@ -14,12 +14,12 @@ export interface SessionGroupBase {
 
 export interface SessionGroup extends SessionGroupBase {
   type: 'Sessions'
-  sessions: Session[]
+  sessions: Array<Session | Session[]>
 }
 
 export interface SessionGroupWithIds extends SessionGroupBase {
   type: 'SessionIds'
-  sessions: string[]
+  sessions: Array<string | string[]> // ['1','2', ['3', '4'], '5']
 }
 
 interface SessionGroups {
@@ -55,7 +55,9 @@ export function useSessionGroups(sessions: Session[]): SessionGroups {
     () =>
       Conference.SessionGroups.map((sessionGroup) => ({
         ...sessionGroup,
-        sessions: getSessionById(sessions, sessionGroup.sessions),
+        sessions: sessionGroup.sessions.map((id) =>
+          typeof id === 'string' ? getSessionById(sessions, [id]) : getSessionById(sessions, id),
+        ),
         type: 'Sessions',
       })),
     // Using the session length as the dependency - there was a reason at the time

--- a/config/conference.ts
+++ b/config/conference.ts
@@ -254,7 +254,7 @@ const Conference: IConference = {
       type: 'SessionIds',
     },
     {
-      sessions: ['343399', '343561', '341315', '340848', '343948', '339017', '343697', '343793', '344491', '344427'],
+      sessions: ['343399', '343561', '341315', '340848', '343948', '339017', '343697', ['343793', '344491'], '344427'],
       timeStart: set(date, { hours: 15, minutes: 15 }),
       timeEnd: set(date, { hours: 15, minutes: 35 }),
       type: 'SessionIds',

--- a/pages/feedback.tsx
+++ b/pages/feedback.tsx
@@ -132,7 +132,7 @@ const Feedback: NextPage<FeedbackProps> = ({ sessions }) => {
             <StyledFormRow>
               <StyledHeadingLabel>Which talk do you want to provide feedback for?</StyledHeadingLabel>
               <StyledSessionList>
-                {sessionGroups.previousSessionGroup.sessions.map((session) => (
+                {sessionGroups.previousSessionGroup.sessions.flat().map((session) => (
                   <li key={session.Id}>
                     <SessionInput session={session} checked={values.sessionId === session.Id} onChange={handleChange} />
                   </li>
@@ -154,7 +154,7 @@ const Feedback: NextPage<FeedbackProps> = ({ sessions }) => {
                             {format(sessionGroup.timeEnd, 'hh:mm')}
                           </time>
                         </StyledSessionTimeframe>
-                        {sessionGroup.sessions.map((session) => (
+                        {sessionGroup.sessions.flat().map((session) => (
                           <li key={session.Id}>
                             <SessionInput
                               session={session}


### PR DESCRIPTION
We had an issue with the slot with two talks in the same room where the "up next" section showed the talks in the wrong rooms. This addresses that issue

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/9972287/188539408-72990e07-4122-40d2-a730-261d62fa0343.png)|![image](https://user-images.githubusercontent.com/9972287/188539350-40f92e5e-60b0-467b-98ef-b8149e0543f9.png)|

Testing:
- [x] Feedback page can see all the talks for feedback
- [x] Agenda page can see the upcoming talks in the right rooms